### PR TITLE
ci: Fix dependencies in unofficial feed.

### DIFF
--- a/.build-tools/updateModuleVersion.ps1
+++ b/.build-tools/updateModuleVersion.ps1
@@ -3,8 +3,10 @@ param (
     [Parameter(Mandatory=$true)][string]$relativePathToManifest,
     [switch]$IsOfficial = $false
 )
+
 Write-Output "----START: updateModuleVersion----"
 Write-Output "----IsOfficial: $IsOfficial----"
+
 #Install all RequiredModules in the module manifests because the command Update-ModuleManifest 
 # requires these modules to be on the host in order to run properly.
 $repoRoot = "$env:SYSTEM_DEFAULTWORKINGDIRECTORY"
@@ -15,18 +17,7 @@ Get-Content "$manifestAbsolutePath"
 Write-Output "---- Updating the module version to $env:BUILD_BUILDNUMBER----"
 
 Set-Location "$manifestFolder"
-$targetModuleParams = @{}
-if (!$IsOfficial) {
-    $extModuleArray = @()
-    $requiredModules = (Test-ModuleManifest "$manifestAbsolutePath" -ErrorAction SilentlyContinue).RequiredModules
-    foreach ($module in $requiredModules) {
-        $extModuleArray += $($module.Name)
-    }
-    $targetModuleParams = @{ModuleVersion = "$env:BUILD_BUILDNUMBER"; ExternalModuleDependencies = $extModuleArray ; Path = "$manifestAbsolutePath"}
-    
-}else {
-    $targetModuleParams = @{ModuleVersion = "$env:BUILD_BUILDNUMBER"; Path = "$manifestAbsolutePath"}
-}
+$targetModuleParams = @{ModuleVersion = "$env:BUILD_BUILDNUMBER"; Path = "$manifestAbsolutePath"}
 Update-ModuleManifest @targetModuleParams
 if (!$?) {
     Write-Error -Message "FAILED: Could not update module version"

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -122,7 +122,7 @@
             # RequireLicenseAcceptance = $false
 
             # External dependent modules of this module
-            # ExternalModuleDependencies = @("VMware.vSphere.SsoAdmin", "VMware.VimAutomation.Core", "VMware.VimAutomation.Storage")
+            # ExternalModuleDependencies = @()
 
         } # End of PSData hashtable
 

--- a/package/packageModule.ps1
+++ b/package/packageModule.ps1
@@ -18,8 +18,8 @@ if ($buildType -eq 'official') {
 }elseif ($buildType -eq 'unofficial') {
     $feedParameters = @{
         Name = "Unofficial-AVS-Automation-AdminTools"
-        SourceLocation = "https://pkgs.dev.azure.com/avs-oss/Public/_packaging/Unofficial-AVS-Automation-AdminTools/nuget/v3/index.json"
-        PublishLocation = "https://pkgs.dev.azure.com/avs-oss/Public/_packaging/Unofficial-AVS-Automation-AdminTools/nuget/v3/index.json"
+        SourceLocation = "https://pkgs.dev.azure.com/avs-oss/Public/_packaging/Unofficial-AVS-Automation-AdminTools/nuget/v2"
+        PublishLocation = "https://pkgs.dev.azure.com/avs-oss/Public/_packaging/Unofficial-AVS-Automation-AdminTools/nuget/v2"
         InstallationPolicy = 'Trusted'
     }
     Write-Output "----Registering PSRepository ----"

--- a/tests/prevalidateModules.ps1
+++ b/tests/prevalidateModules.ps1
@@ -3,15 +3,14 @@ param (
     [Parameter(Mandatory=$true)][string]$modulesFolderPath
 )
 
-Install-Module -Name "PSScriptAnalyzer" -RequiredVersion 1.19.1 -Force
-$repoRoot = "$env:SYSTEM_DEFAULTWORKINGDIRECTORY"
-$fileExtList = @("*.ps1","*.psm1","*.psd1")
 $script:zeroPSAnalyzerErrorsFound = $true
 $script:zeroTestScriptFileInfoErrorsFound = $true
 $script:zeroTestModuleManifestErrorsFound = $true
+
 function Get-PrevalidationResults {
     param (
-        [string]$targetDir
+        [string]$targetDir,
+        $fileExtList
     )
     $scriptsToAnalyze = (Get-ChildItem "$targetDir\*" -Recurse -Include $fileExtList)
 
@@ -56,7 +55,11 @@ function Get-PrevalidationResults {
 
 Write-Output "---- START: Pre-Validation----"
 
-Get-PrevalidationResults (Join-Path -Path $repoRoot -ChildPath $modulesFolderPath)
+Install-Module -Name "PSScriptAnalyzer" -RequiredVersion 1.19.1 -Force
+$repoRoot = "$env:SYSTEM_DEFAULTWORKINGDIRECTORY"
+$fileExtList = @("*.ps1","*.psm1","*.psd1")
+
+Get-PrevalidationResults (Join-Path -Path $repoRoot -ChildPath $modulesFolderPath) $fileExtList
 
 if (!$script:zeroPSAnalyzerErrorsFound) {
     Write-Error -Message "PRE-VALIDATION FAILED: PSScriptAnalyzer found errors"


### PR DESCRIPTION
Resolved issue where AVS.Management RequiredModules were not listed in Unofficial feed and not automatically installed with Primary module*. 

*Note: VMware module dependencies were manually added to unofficial feed. 