### PR TITLE
add empty params to ensure attribute is applied to the function

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -397,6 +397,7 @@ function New-AvsLDAPSIdentitySource {
 #>
 function Get-ExternalIdentitySources {
     [AVSAttribute(3, UpdatesSDDC = $false)]
+    Param()
 
     $ExternalSource = Get-IdentitySource -External
     if ($null -eq $ExternalSource) {
@@ -738,6 +739,7 @@ function Remove-GroupFromCloudAdmins {
 function Get-CloudAdminUsers {
     [CmdletBinding(PositionalBinding = $false)]
     [AVSAttribute(3, UpdatesSDDC = $false)]
+    Param()
 
     $CloudAdmins = Get-SsoGroup -Name 'CloudAdmins' -Domain 'vsphere.local'
     if ($null -eq $CloudAdmins) {
@@ -754,6 +756,7 @@ function Get-CloudAdminUsers {
 #>
 function Get-StoragePolicies {
     [AVSAttribute(3, UpdatesSDDC = $False)]
+    Param()
     
     $StoragePolicies
     try {


### PR DESCRIPTION
Otherwise the attribute is applied to the 1st statement of the function instead of the function itself.