### PR TITLE
update docker image version for testing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -200,7 +200,7 @@ sshLogin $ESX_Credentials
 The final QA cycle would be:
 - Publish the package with `-preview` suffix
 - Get on the Linux jumpbox connected to your SDDC vnet
-- install docker and spin up an instance of this image: mcr.microsoft.com/powershell:7.2.0-alpine-3.12-20211116
+- install docker and spin up an instance of this image: mcr.microsoft.com/powershell:7.2.1-alpine-3.14-20211215
 - In the PowerShell container:
     - Install only your package from PS Gallery – this is to ensure that your package has correctly specified all the dependencies
     - Setup the context


### PR DESCRIPTION
We've moved to mcr.microsoft.com/powershell:7.2.1-alpine-3.14-20211215, update the docs to reflect that.