### PR TITLE
Remove Get-ProtectedVMs since the scripting user will do this automatically. 

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Microsoft.AVS.Management.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '4.0.0'
+    ModuleVersion     = '5.0.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
This would only affect _new_ versions that would be emitted after this change is merged. Only merge once the scripting user code is rolled out everywhere.