### PR TITLE
bump PowerCLI dependencies

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -53,8 +53,8 @@
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
         @{"ModuleName" = "VMware.vSphere.SsoAdmin"; "RequiredVersion" = "1.3.5" },
-        @{"ModuleName" = "VMware.VimAutomation.Core"; "RequiredVersion" = "12.5.0.19093566" }
-        @{"ModuleName" = "VMware.VimAutomation.Storage"; "RequiredVersion" = "12.5.0.19106817"}
+        @{"ModuleName" = "VMware.VimAutomation.Core"; "RequiredVersion" = "12.7.0.20091293" }
+        @{"ModuleName" = "VMware.VimAutomation.Storage"; "RequiredVersion" = "12.7.0.20091292"}
         @{"ModuleName" = "posh-ssh"; "RequiredVersion" = "3.0.0"}
     )
 


### PR DESCRIPTION
We're 2 releases behind and some modules have loosely-constrained dependencies, which results in loading some of 12.7 dependencies anyway.