### PR TITLE
create a new cmdlet to update the password for Identity Source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/.idea/

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -52,7 +52,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
-        @{"ModuleName" = "VMware.vSphere.SsoAdmin"; "RequiredVersion" = "1.3.5" },
+        @{"ModuleName" = "VMware.vSphere.SsoAdmin"; "RequiredVersion" = "1.3.7" },
         @{"ModuleName" = "VMware.VimAutomation.Core"; "RequiredVersion" = "12.7.0.20091293" }
         @{"ModuleName" = "VMware.VimAutomation.Storage"; "RequiredVersion" = "12.7.0.20091292"}
         @{"ModuleName" = "posh-ssh"; "RequiredVersion" = "3.0.0"}
@@ -76,7 +76,7 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @("Set-VMStoragePolicy", "Set-LocationStoragePolicy", "Set-ClusterDefaultStoragePolicy", "Get-StoragePolicies", "New-LDAPIdentitySource", "New-LDAPSIdentitySource", "Update-IdentitySourceCertificates", "Get-ExternalIdentitySources", "Remove-ExternalIdentitySources", "Add-GroupToCloudAdmins", "Remove-GroupFromCloudAdmins", "Get-CloudAdminGroups")
+    FunctionsToExport = @("Set-VMStoragePolicy", "Set-LocationStoragePolicy", "Set-ClusterDefaultStoragePolicy", "Get-StoragePolicies", "New-LDAPIdentitySource", "New-LDAPSIdentitySource", "Update-IdentitySourceCertificates", "Get-ExternalIdentitySources", "Remove-ExternalIdentitySources", "Add-GroupToCloudAdmins", "Remove-GroupFromCloudAdmins", "Get-CloudAdminGroups", "Update-IdentitySourcePassword")
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -52,7 +52,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
-        @{"ModuleName" = "VMware.vSphere.SsoAdmin"; "RequiredVersion" = "1.3.7" },
+        @{"ModuleName" = "VMware.vSphere.SsoAdmin"; "RequiredVersion" = "1.3.8" },
         @{"ModuleName" = "VMware.VimAutomation.Core"; "RequiredVersion" = "12.7.0.20091293" }
         @{"ModuleName" = "VMware.VimAutomation.Storage"; "RequiredVersion" = "12.7.0.20091292"}
         @{"ModuleName" = "posh-ssh"; "RequiredVersion" = "3.0.0"}

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -76,7 +76,7 @@
     # NestedModules = @()
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = @("Set-VMStoragePolicy", "Set-LocationStoragePolicy", "Set-ClusterDefaultStoragePolicy", "Get-StoragePolicies", "New-LDAPIdentitySource", "New-LDAPSIdentitySource", "Update-IdentitySourceCertificates", "Get-ExternalIdentitySources", "Remove-ExternalIdentitySources", "Add-GroupToCloudAdmins", "Remove-GroupFromCloudAdmins", "Get-CloudAdminGroups", "Update-IdentitySourcePassword")
+    FunctionsToExport = @("Set-VMStoragePolicy", "Set-LocationStoragePolicy", "Set-ClusterDefaultStoragePolicy", "Get-StoragePolicies", "New-LDAPIdentitySource", "New-LDAPSIdentitySource", "Update-IdentitySourceCertificates", "Get-ExternalIdentitySources", "Remove-ExternalIdentitySources", "Add-GroupToCloudAdmins", "Remove-GroupFromCloudAdmins", "Get-CloudAdminGroups", "Update-IdentitySourceCredential")
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport   = @()

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -707,6 +707,53 @@ function Add-GroupToCloudAdmins {
 
 <#
     .Synopsis
+     Update the password used in the credential for authenticating to an Active Directory
+
+    .Parameter Credential 
+     Credential to login to the LDAP server (NOT cloudadmin) in the form of a username/password credential. Usernames often look like prodAdmins@domainname.com or if the AD is a Microsoft Active Directory server, usernames may need to be prefixed with the NetBIOS domain name, such as prod\AD_Admin
+    
+     .Parameter DomainName
+     Domain name of the external active directory, e.g. myactivedirectory.local
+#>
+function Update-IdentitySourcePassword {
+    [CmdletBinding(PositionalBinding = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param
+    (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Name of the Identity source')]
+        [ValidateNotNull()]
+        [string]
+        $DomainName,
+
+        [Parameter(Mandatory = $true,
+                HelpMessage = "Credential for the LDAP server")]
+        [ValidateNotNull()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential
+    )
+
+    $ExternalIdentitySources = Get-IdentitySource -External -ErrorAction Stop
+    if ($null -ne $ExternalIdentitySources) {
+        $IdentitySource = $ExternalIdentitySources | Where-Object {$_.Name -eq $DomainName}
+        if ($null -ne $IdentitySource) {
+            Write-Host "Updating the LDAP Identity Source..."
+            Set-LDAPIdentitySource -IdentitySource $IdentitySource -Credential $Credential -ErrorAction Stop
+            $ExternalIdentitySources = Get-IdentitySource -External -ErrorAction Continue
+            $ExternalIdentitySources | Format-List | Out-String
+        } else {
+            throw "Could not find Identity Source with name: $DomainName."
+        }
+    }
+    else {
+        throw "No existing external identity sources found."
+    }
+}
+
+<#
+    .Synopsis
      Remove a previously added group from an external identity from the CloudAdmins group
 
     .Parameter GroupName

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -715,7 +715,7 @@ function Add-GroupToCloudAdmins {
      .Parameter DomainName
      Domain name of the external active directory, e.g. myactivedirectory.local
 #>
-function Update-IdentitySourcePassword {
+function Update-IdentitySourceCredential {
     [CmdletBinding(PositionalBinding = $false)]
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -707,13 +707,13 @@ function Add-GroupToCloudAdmins {
 
 <#
     .Synopsis
-     Update the password used in the credential for authenticating to an Active Directory
+     Update the password used in the credential to authenticate an LDAP server
 
     .Parameter Credential 
      Credential to login to the LDAP server (NOT cloudadmin) in the form of a username/password credential. Usernames often look like prodAdmins@domainname.com or if the AD is a Microsoft Active Directory server, usernames may need to be prefixed with the NetBIOS domain name, such as prod\AD_Admin
     
      .Parameter DomainName
-     Domain name of the external active directory, e.g. myactivedirectory.local
+     Domain name of the external LDAP server, e.g. myactivedirectory.local
 #>
 function Update-IdentitySourceCredential {
     [CmdletBinding(PositionalBinding = $false)]


### PR DESCRIPTION
Problem
Users are not able to update the password of Identity Source in the vCenter after the password is changed in the AD server.

Solution
Create a new cmdlet to let users update the password.

Testing
<img width="408" alt="image" src="https://user-images.githubusercontent.com/60164697/209735262-2e14d3ec-1457-4bdb-ad3a-63e6d711a0cd.png">

Logs and metrics
n/a

Upcoming changes
n/a