### PR TITLE
Updated User Permissions

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1080,7 +1080,11 @@ function Set-HcxScaledCpuAndMemorySetting {
         $Group = 'CloudAdmins'
 
         Write-Host "Creating new temp scripting user"
-        $HcxAdminCredential = New-TempUser -privileges @("VirtualMachine.Config.CPUCount","VirtualMachine.Config.Memory") -userName $UserName -userRole $UserRole
+        $privileges = @("VirtualMachine.Config.CPUCount",
+                        "VirtualMachine.Config.Memory",
+                        "VirtualMachine.Interact.PowerOff",
+                        "VirtualMachine.Interact.PowerOn")
+        $HcxAdminCredential = New-TempUser -privileges $privileges -userName $UserName -userRole $UserRole
         Connect-VIServer -Server $VC_ADDRESS -Credential $HcxAdminCredential | Out-Null
 
         $Port = 443


### PR DESCRIPTION
## Problem
Without the specified permissions of "VirtualMachine.Interact.PowerOff" and "VirtualMachine.Interact.PowerOn" a user does not have the permission to change the power state of a VM. This will cause the "Set-HcxScaledCpuAndMemorySetting" during execution

## Solution
Allow the new user to turn vm on/off with the specified permissions