### PR TITLE
Update PSScriptInfo

### DIFF
--- a/Microsoft.AVS.Management/HcxUtils.ps1
+++ b/Microsoft.AVS.Management/HcxUtils.ps1
@@ -1,3 +1,17 @@
+<#PSScriptInfo
+    .VERSION 1.0
+
+    .GUID 953d76b2-f8ef-4a8c-9754-44fef24ecb93
+
+    .AUTHOR Frantz Prinvil
+
+    .COMPANYNAME Microsoft
+
+    .COPYRIGHT (c) Microsoft. All rights reserved.
+
+    .DESCRIPTION PowerShell Cmdlets for Managing Hybrid Cloud Extension (HCX) on VMware Cloud on AWS
+#>
+
 <#
     .Synopsis
     Get the authorization token found in the response headers under the name of 'x-hm-authorization'

--- a/Microsoft.AVS.Management/UserUtils.ps1
+++ b/Microsoft.AVS.Management/UserUtils.ps1
@@ -1,3 +1,17 @@
+<#PSScriptInfo
+    .VERSION 1.0
+
+    .GUID f58381a2-e11d-46c8-aec9-fa3fcd6bd65a
+
+    .AUTHOR Frantz Prinvil
+
+    .COMPANYNAME Microsoft
+
+    .COPYRIGHT (c) Microsoft. All rights reserved.
+
+    .DESCRIPTION PowerShell Cmdlets to Support User Functionalities
+#>
+
 <#
     .Synopsis
     Adds a user account to an existing group


### PR DESCRIPTION
## Problem
Executing Test-ScriptFileInfo on both new file causes the error error message `Test-ScriptFileInfo : PSScriptInfo is not specified in the script file '[File_Path]'. You can use the Update-ScriptFileInfo with -Force or New-ScriptFileInfo cmdlet to add the PSScriptInfo to the script file.`

## Solution
Updating information for new scripts

Reference: `https://learn.microsoft.com/en-us/powershell/module/PowerShellGet/test-scriptfileinfo?view=powershell-7.3`

## Testing
n/a

## Logs and metrics
n/a

## Upcoming changes
n/a