### PR TITLE
doc: clarify when execution can occur

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ The script shall assume the directory it is executed in is temporary and can use
 
 ## Script Execution
 
-Script executions are serialized (executed one at a time) for the safety of all parties.
+Script executions are serialized (executed one at a time) for the safety of all parties.  Scripts are not executed when the SDDC is the `Updating` state.  A script can set the SDDC state to `Updating` using an `AVSAttribute`, see below.
 
 ## Script Termination
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,9 @@ The script shall assume the directory it is executed in is temporary and can use
 
 ## Script Execution
 
-Script executions are serialized (executed one at a time) for the safety of all parties.  Scripts are not executed when the SDDC is the `Updating` state.  A script can set the SDDC state to `Updating` using an `AVSAttribute`, see below.
+Script executions are serialized (executed one at a time) for the safety of all parties.
+
+If a script executes against an SDDC in the `Updating` state it will result in an error.  A script can set the SDDC state to `Updating` using an `AVSAttribute`, see below.
 
 ## Script Termination
 


### PR DESCRIPTION
Scripts are not executed when the SDDC is the Updating state.  A script can set the SDDC state to the Updating state if necessary using an AVSAttribute.