### PR TITLE
Fix context variable

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -292,20 +292,20 @@ function Get-CertificateFromDomainController {
 
     try {
         $Command = 'nslookup ' + $ParsedUrl.Host + ' -type=soa'
-        $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC']
+        $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
         if ($SSHRes.ExitStatus -ne 0) {
             throw "The FQDN $($ParsedUrl.Host) cannot be resolved to an IP address. Make sure DNS is configured."
         }
 
         $Command = 'nc -vz ' + $ParsedUrl.Host + ' ' + $ParsedUrl.Port
-        $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC']
+        $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
         if ($SSHRes.ExitStatus -ne 0) {
             throw "The connection cannot be established. Please check the address, routing and/or firewall and make sure port $($ParsedUrl.Port) is open."
         }
 
         Write-Host ("Starting to Download Cert from " + $computerUrl)
         $Command = 'echo "1" | openssl s_client -connect ' + $ParsedUrl.Host + ':' + $ParsedUrl.Port + ' -showcerts'
-        $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC']
+        $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
         $SSHOutput = $SSHRes.Output | out-string
     } catch {
         throw "Failure to download the certificate from $computerUrl. $_"


### PR DESCRIPTION
Problem: Fix bugs, changing environment variable from `$SSH_Sessions['VC']` to `$SSH_Sessions['VC'].Value`
Solution: Use a lazy instance of posh-ssh session for the value of the dictionary.

<img width="404" alt="image" src="https://user-images.githubusercontent.com/60164697/215626133-cdbb0937-494c-4b61-b61e-964209944c5d.png">
<img width="384" alt="image" src="https://user-images.githubusercontent.com/60164697/215626156-5ca5a6b2-7e42-4804-8949-3d177ddc9dd8.png">
