### PR TITLE
Allow customer to control vSAN compression and deduplication

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -94,6 +94,7 @@
          "Set-HcxScaledCpuAndMemorySetting"
          "Restart-HcxManager"
          "Set-ToolsRepo"
+         "Set-vSANCompressDedupe"
        )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1609,7 +1609,7 @@ function Set-vSANCompressDedupe
     }
     else
     {
-        foreach ($cluster_each in ($Cluster.split(",")).Trim())
+        foreach ($cluster_each in ($Cluster.split(",",[System.StringSplitOptions]::RemoveEmptyEntries)).Trim())
         {
             $Clusters += Get-Cluster -Name $cluster_each
         }

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1596,10 +1596,7 @@ function Set-vSANCompressDedupe
         [bool]$Deduplication = $false,
         [Parameter(Mandatory = $false,
         HelpMessage = "Enable compression only.")]
-        [bool]$Compression = $true,
-        [Parameter(Mandatory = $false,
-        HelpMessage = "Neither compression nor deduplication.")]
-        [bool]$Neither = $false
+        [bool]$Compression = $false
     )
 
     # $cluster is an array of cluster names or "all"
@@ -1625,17 +1622,11 @@ function Set-vSANCompressDedupe
             Write-Host "Enabling deduplication and compression on $cluster_name"
             Set-VsanClusterConfiguration -Configuration $cluster_name -SpaceEfficiencyEnabled $true
         }
-        elseif ($Compression -eq $true)
+        elseif (($Compression -eq $true) -and ($Deduplication -eq $false))
         {
             # Compression only
             Write-Host "Enabling compression on $cluster_name"
             Set-VsanClusterConfiguration -Configuration $cluster_name -SpaceCompressionEnabled $true
-        }
-        elseif ($Neither -eq $true)
-        {
-            # Neither compression nor deduplication
-            Write-Host "Disabling compression and deduplication on $cluster_name"
-            Set-VsanClusterConfiguration -Configuration $cluster_name -SpaceEfficiencyEnabled $false
         }
     }
 }

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1587,7 +1587,7 @@ function Set-ToolsRepo
 
 function Set-vSANCompressDedupe
 {
-    [AVSAttribute(120, UpdatesSDDC = $true)]
+    [AVSAttribute(60, UpdatesSDDC = $true)]
     param(
         [Parameter(Mandatory = $true)]
         [String]$Cluster,


### PR DESCRIPTION
We enable compression and deduplication by default. This allows the customer to disable some or all if they choose to.