### PR TITLE
New cmdlet to update password of identity source

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -52,7 +52,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
-        @{"ModuleName" = "VMware.vSphere.SsoAdmin"; "RequiredVersion" = "1.3.5" },
+        @{"ModuleName" = "VMware.vSphere.SsoAdmin"; "RequiredVersion" = "1.3.8" },
         @{"ModuleName" = "VMware.VimAutomation.Core"; "RequiredVersion" = "12.7.0.20091293" }
         @{"ModuleName" = "VMware.VimAutomation.Storage"; "RequiredVersion" = "12.7.0.20091292"}
         @{"ModuleName" = "VMware.VimAutomation.Hcx"; "RequiredVersion" = "12.7.0.20091291"}
@@ -85,6 +85,7 @@
          "New-LDAPIdentitySource"
          "New-LDAPSIdentitySource"
          "Update-IdentitySourceCertificates"
+         "Update-IdentitySourceCredential"
          "Get-ExternalIdentitySources"
          "Remove-ExternalIdentitySources"
          "Add-GroupToCloudAdmins"


### PR DESCRIPTION
Problem
Users are not able to update the password of Identity Source in the vCenter after the password is changed in the AD server.

Solution
Create a new cmdlet to let users update the password.

Testing
![image](https://user-images.githubusercontent.com/60164697/224427416-aa615451-347d-4385-bebd-e7fc184c78b9.png)


Logs and metrics
n/a

Upcoming changes
n/a