### PR TITLE
Add API to rescan storage

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -72,7 +72,8 @@
         "New-VmfsDatastore",
         "Dismount-VmfsDatastore",
         "Resize-VmfsVolume",
-        "Restore-VmfsVolume"
+        "Restore-VmfsVolume",
+        "Sync-VMHostStorage"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -486,7 +486,7 @@ function Sync-VMHostStorage {
     Param (
         [Parameter(
                 Mandatory=$true,
-                HelpMessage = 'VMost name')]
+                HelpMessage = 'VMHost name')]
         [ValidateNotNull()]
         [String]
         $VMHostName

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -462,3 +462,35 @@ function Restore-VmfsVolume {
 
     $Esxi | Get-VMHostStorage -RescanVMFS -ErrorAction stop | Out-Null
 }
+
+<#
+    .SYNOPSIS
+     Rescans host storage
+
+    .PARAMETER VMHostName
+     Name of the VMHost (ESXi server)
+
+
+    .EXAMPLE
+     Sync-VMHostStorage -VMHostName "vmhost1"
+
+    .INPUTS
+     VMHostName.
+
+    .OUTPUTS
+     None.
+#>
+function Sync-VMHostStorage {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param (
+        [Parameter(
+                Mandatory=$true,
+                HelpMessage = 'VMost name')]
+        [ValidateNotNull()]
+        [String]
+        $VMHostName
+    )
+
+    Get-VMHost $VMHostName | Get-VMHostStorage -RescanAllHba -RescanVMFS | Out-Null
+}


### PR DESCRIPTION
Sync-VMhostStorage API is added to enable rescanning VMHostStorage

Motivation for the update: Some workflows such as creating a datastore from snapshot do not work properly untill storage is re-scanned.

Testing: We have tested it on local deployments of VMWare (not in Azure) using PowerShell Pester tests.