### PR TITLE
Add API to remove the static iSCSI configurations from a specified host

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -74,7 +74,7 @@
         "Resize-VmfsVolume",
         "Restore-VmfsVolume",
         "Sync-VMHostStorage",
-        "Remove-VMHostStaticiSCSITargets"
+        "Remove-VMHostStaticIScsiTargets"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -73,7 +73,8 @@
         "Dismount-VmfsDatastore",
         "Resize-VmfsVolume",
         "Restore-VmfsVolume",
-        "Sync-VMHostStorage"
+        "Sync-VMHostStorage",
+        "Remove-VMHostStaticiSCSITargets"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -508,5 +508,10 @@ function Remove-VMHostStaticiSCSITargets {
         [String]
         $VMHostName
     )
-    Get-VMHost $VMHostName | Get-VMHostHba -Type iScsi | Get-IScsiHbaTarget | Where {$_.Type -eq "Static"} | Remove-IScsiHbaTarget -Confirm:$false
+
+    $VMHost = Get-VMHost $VMHostName -ErrorAction Ignore
+    if (-not $VMHost) {
+        throw "VMHost $VMHostName does not exist."
+    }
+    $VMHost| Get-VMHostHba -Type iScsi | Get-IScsiHbaTarget | Where {$_.Type -eq "Static"} | Remove-IScsiHbaTarget -Confirm:$false
 }

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -480,3 +480,33 @@ function Sync-VMHostStorage {
 
     Get-VMHost $VMHostName | Get-VMHostStorage -RescanAllHba -RescanVMFS | Out-Null
 }
+
+<#
+    .SYNOPSIS
+     This function removes the static iSCSI configurations from a specified Esxi Host
+
+    .PARAMETER VMHostName
+     Name of the VMHost (ESXi server)
+
+    .EXAMPLE
+     Sync-VMHostStorage -VMHostName "vmhost1"
+
+    .INPUTS
+     VMHostName
+
+    .OUTPUTS
+     None
+#>
+function Remove-VMHostStaticiSCSITargets {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param (
+        [Parameter(
+                Mandatory=$true,
+                HelpMessage = 'VMost name')]
+        [ValidateNotNull()]
+        [String]
+        $VMHostName
+    )
+    Get-VMHost $VMHostName | Get-VMHostHba -Type iScsi | Get-IScsiHbaTarget | Where {$_.Type -eq "Static"} | Remove-IScsiHbaTarget -Confirm:$false
+}

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -492,7 +492,7 @@ function Sync-VMHostStorage {
      iSCSI target address. Multiple addresses can be seperated by ","
 
     .EXAMPLE
-     Remove-VMHostStaticiSCSITargets -ClusterName "myCluster" -ISCSIAddress "192.168.1.10,192.168.1.11"
+     Remove-VMHostStaticIScsiTargets -ClusterName "myCluster" -ISCSIAddress "192.168.1.10,192.168.1.11"
 
     .INPUTS
      vCenter cluster name and iSCSi target address
@@ -500,7 +500,7 @@ function Sync-VMHostStorage {
     .OUTPUTS
      None
 #>
-function Remove-VMHostStaticiSCSITargets {
+function Remove-VMHostStaticIScsiTargets {
     [CmdletBinding()]
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param (

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -503,7 +503,7 @@ function Remove-VMHostStaticiSCSITargets {
     Param (
         [Parameter(
                 Mandatory=$true,
-                HelpMessage = 'VMost name')]
+                HelpMessage = 'VMHost name')]
         [ValidateNotNull()]
         [String]
         $VMHostName

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -489,7 +489,7 @@ function Sync-VMHostStorage {
      Name of the VMHost (ESXi server)
 
     .EXAMPLE
-     Sync-VMHostStorage -VMHostName "vmhost1"
+     Remove-VMHostStaticiSCSITargets -VMHostName "vmhost1"
 
     .INPUTS
      VMHostName


### PR DESCRIPTION
Add function Remove-VMHostStaticiSCSITargets to remove static iSCSI configuration.
Motivation: This can be used when adding/removing new hosts to AVS deployment
Testing: We have tested it on local VMware deployments (not in Azure) using PowerShell Pester tests