### PR TITLE
Rescan all hosts after restoring a datastore

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -460,5 +460,5 @@ function Restore-VmfsVolume {
 
     Start-Sleep -s 5
 
-    $Esxi | Get-VMHostStorage -RescanVMFS -ErrorAction stop | Out-Null
+    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba -RescanVMFS | Out-Null
 }


### PR DESCRIPTION
Motivation: Need to make sure that the datastore is available on all hosts
Testing: Pester tests using local VMWare deployment