### PR TITLE
Rescans all host storage in cluster

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -73,7 +73,8 @@
         "Dismount-VmfsDatastore",
         "Resize-VmfsVolume",
         "Restore-VmfsVolume",
-        "Sync-VMHostStorage"
+        "Sync-VMHostStorage",
+        "Sync-ClusterVMHostStorage"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -480,3 +480,39 @@ function Sync-VMHostStorage {
 
     Get-VMHost $VMHostName | Get-VMHostStorage -RescanAllHba -RescanVMFS | Out-Null
 }
+
+<#
+    .SYNOPSIS
+     Rescans all host storage in cluster
+
+    .PARAMETER ClusterName
+     Cluster name
+
+    .EXAMPLE
+     Sync-ClusterVMHostStorage -ClusterName "myClusterName"
+
+    .INPUTS
+     vCenter cluster name
+
+    .OUTPUTS
+     None
+#>
+function Sync-ClusterVMHostStorage {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param (
+        [Parameter(
+                Mandatory=$true,
+                HelpMessage = 'Cluster name in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $ClusterName
+    )
+
+    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
+    if (-not $Cluster) {
+        throw "Cluster $ClusterName does not exist."
+    }
+
+    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba -RescanVMFS | Out-Null
+}


### PR DESCRIPTION
Motivation: We want to reduce RunCommand overhead of re-scanning individual ESXi hosts one at a time in some workflows
Testing: Pester tests using local VMware deployment