### PR TITLE
method to secure existing objects in a folder

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -40,6 +40,15 @@ class AVSSecureFolder {
     }
 
     <#
+        Secure all objects in the specified folder.
+    #>
+    static Secure([VMware.VimAutomation.ViCore.Types.V1.Inventory.Folder]$folder) {
+        $noAccess = Get-VIRole -Name "NoAccess" -ErrorAction Stop
+        $group = Get-VIAccount -Group -Id "CloudAdmins" -Domain "vsphere.local" -ErrorAction Stop
+        (Get-VM -Location $folder) + (Get-VApp -Location $folder) | New-VIPermission -Principal $group -Role $noAccess -Propagate $true
+    }
+
+    <#
         Creates a subfolder or returns existing one given the name.
         Returns $null in case of any error.
     #>

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ If necessary, use the installation script to create a separate vCenter user and 
 If deploying an appliance in customer infrastruture that needs service credentials with privileges above `cloudadmins` role the vendor must ensure that the credentials are never exposed - not in-flight, nor at rest.
 - The appliance user must not be able to gain root access or direct access to the storage or file system where credetials are stored.
 - The appliance must be deployed in a folder with NoAccess permission to `CloudAdmins` SSO group. See `[AVSSecureFolder]::Root()` and `[AVSSecureFolder]::GetOrCreate()`.
+- The objects deployed into the secure folder must subseqently be re-secured with `[AVSSecureFolder]::Secure()` method.
 - The credentials must be passed as OVA properties to the appliance, including the rotation scenario.
 - The credentials must never be logged, no diagnostic bundle may include the credentials.
 - The vendor must provide the cmdlets to rotate the service account password and perform any appliance updates, including security patches.


### PR DESCRIPTION
This PR follows up to #130 

The changes in this PR are as follows:

* Adds a method to secure existing objects in a folder

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

