### PR TITLE
adjust for potential non-collection types

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -45,7 +45,7 @@ class AVSSecureFolder {
     static Secure([VMware.VimAutomation.ViCore.Types.V1.Inventory.Folder]$folder) {
         $noAccess = Get-VIRole -Name "NoAccess" -ErrorAction Stop
         $group = Get-VIAccount -Group -Id "CloudAdmins" -Domain "vsphere.local" -ErrorAction Stop
-        (Get-VM -Location $folder) + (Get-VApp -Location $folder) | New-VIPermission -Principal $group -Role $noAccess -Propagate $true
+        @(Get-VM -Location $folder) + @(Get-VApp -Location $folder) | New-VIPermission -Principal $group -Role $noAccess -Propagate $true
     }
 
     <#


### PR DESCRIPTION
This PR fixes issue with #170 in case there <=1 objects of given type.

The changes in this PR are as follows:

* always treat the items as collection

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

