### PR TITLE
Enable to create distributed port groups for a given distributed switch 

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -77,7 +77,8 @@
         "Sync-ClusterVMHostStorage",
         "Remove-VMHostStaticIScsiTargets",
         "Connect-NVMeTCPTarget",
-        "Disconnect-NVMeTCPTarget"
+        "Disconnect-NVMeTCPTarget",
+        "New-NVMeTCPPortGroups"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -75,7 +75,9 @@
         "Restore-VmfsVolume",
         "Sync-VMHostStorage",
         "Sync-ClusterVMHostStorage",
-        "Remove-VMHostStaticIScsiTargets"
+        "Remove-VMHostStaticIScsiTargets",
+        "Connect-NVMeTCPTarget",
+        "Disconnect-NVMeTCPTarget"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -844,3 +844,73 @@ function Disconnect-NVMeTCPTarget {
         Write-Host ""
     }
 }
+
+<#
+    .SYNOPSIS
+     This function creates port groups for a given Distributed Switch.
+
+     1. Distributed Switch Name
+     2. List of PortGroup Name
+
+    .PARAMETER DSwitchName
+     Distributed Switch Name
+    
+    .PARAMETER PortGroupsCount
+     List of PortGroup Name
+
+    .EXAMPLE
+     New-NVMeTCPPortGroups -DSwitchName "DSwitchName-001"  -PortGroupsName "PGroup1", "PGroup2" 
+
+    .INPUTS
+     Distributed Switch Name, List of PortGroup Name
+
+    .OUTPUTS
+     None.
+#>
+function New-NVMeTCPPortGroups {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+   
+    Param
+    (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Distributed Switch Name')]
+        [String] $DSwitchName,
+                
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'List of portgroup Name')]
+        [string[]] $PortGroupsName  
+    )
+
+    Write-Host "Creating PortGroups for a given Distributed Switch " $DSwitchName
+    Write-Host " " ;
+
+    $DSName = Get-VDSwitch -Name $DSwitchName -ErrorAction Ignore
+    if (-not $DSName) {
+        throw "Distributed $DSwitchName does not exist."
+    }
+
+    if ($null -eq $PortGroupsName ) {
+        throw "Provide Distributed portgroup Names."
+    }
+
+    
+    foreach ($item in $PortGroupsName) {
+            
+        try {
+                     
+            $PGroup = New-VDPortgroup -VDSwitch $DSName   -Name $item
+            Write-Host "PortGroup created successfully: " $PGroup
+           
+        }
+        catch {
+
+            Write-Error "Failed to create Distributed Port Group $(PortGroupNamePattern),
+                     continue connecting creating rest of the portgroups"
+                    
+        }
+    }
+
+}

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -797,7 +797,7 @@ function Disconnect-NVMeTCPTarget {
         }
     }
     catch {
-        throw "Failed to execute Get-EsxCli cmdlet on host $($HostAddress). Make sure valid ESXi IP/DNS is provided."
+        throw "Failed to execute Get-EsxCli cmdlet on host $($HostAddress). Make sure valid ESXi IP/DNS is provided. $($_.Exception)"
     }
 
     try {
@@ -823,7 +823,7 @@ function Disconnect-NVMeTCPTarget {
         } 
     }
     catch {
-        throw "Failed to execute Get-EsxCli cmdlet on host $($HostAddress). Make sure valid ESXi IP/DNS is provided."
+        throw "Failed to execute EsxCli on host $($HostAddress). Make sure valid ESXi IP/DNS is provided. $($_.Exception)"
     } 
     Write-Host ""
 }

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -568,3 +568,262 @@ function Remove-VMHostStaticIScsiTargets {
     # Rescan after removing the iSCSI targets
     $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba -RescanVMFS | Out-Null
 }
+
+
+<#
+    .SYNOPSIS
+     This function connects an esxi host to the specified storage cluster node/target.
+
+     1. ESXi host IP address or DNS
+     2. ESXi NVMe/TCP Storage adaper name 
+     3. Storage Node EndPoint IP address
+     4. Storage SystemNQN 
+     5. NVMe/TCP Admin Queue Size (Optional)
+     6. Controller Id (Optional) 
+     7. IO Queue Number (Optional)
+     8. IO Queue Size (Optional)
+     9. Keep Alive Timeout (Optional)
+     10. Target Port Number (Optional)
+     
+     
+    .PARAMETER HostAddress
+     ESXi host IP Address 
+
+    .PARAMETER HostAdapter
+     ESXi host storage adapter name 
+
+    .PARAMETER NodeAddress
+     Storage Node EndPoint Address
+
+    .PARAMETER StorageSystemNQN
+     Storage system NQN
+    
+    .PARAMETER  AdminQueueSize
+     NVMe/TCP Admin Queue Size, default 32
+
+    .PARAMETER  ControllerId
+     NVMe/TCP Controller ID, default 65535 
+
+    .PARAMETER  IoQueueNumber
+     IO Queue Number, default 8
+
+    .PARAMETER IoQueueSize
+     IO Queue Size, default 256
+     
+    .PARAMETER KeepAliveTimeout
+     Keep Alive Timeout, default 256
+     
+    .PARAMETER  PortNumber
+     Target Port Number, default 4420
+
+    .EXAMPLE
+     Connect-NVMeTCPTarget HostAddress "192.168.0.1" -HostAdapter "adapter-name" -NodeAddress "192.168.0.1" -StorageSystemNQN "nqn.2016-01.com.lightbitslabs:uuid:46edb489-ba18-4dd4-a157-1d8eb8c32e21"
+
+    .INPUTS
+     ESXi Address, Storage Adapter, Storage Node Address, Storage System NQN
+
+    .OUTPUTS
+     None.
+#>
+function Connect-NVMeTCPTarget {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param
+    (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'ESXi host network address')]
+        [string] $HostAddress,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'NVMe/TCP Storage Adapter Name')]
+        [string] $HostAdapter,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Target storage Node datapath address')]
+        [string]     $NodeAddress,
+
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Target storage SystemNQN')]
+        [string]     $StorageSystemNQN,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'NVMe/TCP Admin Queue Size')]
+        [int]     $AdminQueueSize = 32,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'NVMe/TCP Controller Id')]
+        [int]     $ControllerId = 65535,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'NVMe/TCP IO Queue Number')]
+        [int]     $IoQueueNumber = 8,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'NVMe/TCP IO Queue Size')]
+        [int]     $IoQueueSize = 256,
+
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'Keep Alive Timeout')]
+        [int]     $KeepAliveTimeout = 256,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'Port Number')]
+        [int]     $PortNumber = 4420
+
+
+
+    )
+       
+    Write-Host "Connecting to targets via Storage Adapter on given ESXi host " $HostAddress;
+    Write-Host " " ;
+
+    $HostEsxcli = $null;
+ 
+    try {
+        $HostEsxcli = Get-EsxCli -VMHost $HostAddress 
+    }
+    catch {
+        throw "Failed to execute Get-EsxCli cmdlet on host $($HostAddress). Make sure valid ESXi IP/DNS is provided."
+    }
+
+    if ($HostEsxcli) { 
+        Write-Host "Connected to host via PowerCLI-esxcli"
+     
+        try {
+   
+            $EsxCliResult = $HostEsxcli.nvme.fabrics.connect(
+                $HostAdapter, $AdminQueueSize, $ControllerId, 
+                $null, $IoQueueNumber, $IoQueueSize, $NodeAddress,
+                $KeepAliveTimeout, $PortNumber, $StorageSystemNQN, $null, $null 
+            );
+       
+            if ($EsxCliResult) {
+                Write-Host "ESXi host is connected to storage controller " $hostAddress 
+            }
+            else {
+                throw
+            }
+        }
+        catch {
+            throw "Failed to connect ESXi NVMe/TCP storage adapter to storage controller  $($item) " 
+        }  
+        Write-Host "Connecting Controller status: "$EsxCliResult;
+    }
+
+    Write-Host "Rescanning NVMe/TCP storage adapter.."
+
+    $RescanResult = Get-VMHostStorage -VMHost $HostAddress -RescanAllHba 
+    
+    Write-Host "Rescanning Completed."
+
+} 
+ 
+<#
+    .SYNOPSIS
+     This function disconnects an esxi host from the specified storage cluster node/target.
+
+     1. ESXi host IP address or DNS
+     2. ESXi NVMe/TCP Storage adaper name 
+     3. Storage SystemNQN
+
+    .PARAMETER HostAddress
+     ESXi host IP Address 
+
+    .PARAMETER HostAdapter
+     ESXi host storage adapter name
+
+    .PARAMETER StorageSystemNQN
+     Storage system NQN
+
+    .EXAMPLE
+     Disconnect-NVMeTCPTarget -HostAddress "192.168.0.1" -HostAdapter "vmhba64"  -StorageSystemNQN "nqn.2016-01.com.lightbitslabs:uuid:46edb489-ba18-4dd4-a157-1d8eb8c32e21"
+
+    .INPUTS
+     ESXi Address, Storage Adapter, Storage systemNQN
+
+    .OUTPUTS
+     None.
+#>
+function Disconnect-NVMeTCPTarget {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+   
+    Param
+    (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'ESXi host network address')]
+        [string] $HostAddress,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'NVMe/TCP Storage Adapter Name')]
+        [string] $HostAdapter,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Target storage SystemNQN')]
+        [string]     $StorageSystemNQN
+
+
+
+
+    )
+
+    Write-Host "Disconnecting controllers from targets on given ESXi host " $HostAddress;
+    Write-Host " " ;
+    
+    $hostEsxcli = $null;
+
+    try {
+        <#Do this if a terminating exception happens#>
+
+        $HostEsxcli = Get-EsxCli -VMHost $HostAddress ;
+        Write-Host "EsxCli connected to host $($HostAddress)"
+        if ($null -eq $HostEsxcli) {
+            throw;
+        }
+    }
+    catch {
+        throw "Failed to execute Get-EsxCli cmdlet on host $($HostAddress). Make sure valid ESXi IP/DNS is provided."
+    }
+
+    try {
+
+        $Controllers = $HostEsxcli.nvme.controller.list();
+
+        if ($Controllers -and $Controllers.Count -ge 0) {
+
+            foreach ($item in $Controllers) {
+                $result = $HostEsxcli.nvme.fabrics.disconnect($item.Adapter, $item.ControllerNumber, $StorageSystemNQN);
+                Write-Host "Diconnecting Controller status: "$result;
+            }
+       
+            Write-Host "Rescanning NVMe/TCP storage adapter.."
+            $RescanResult = Get-VMHostStorage -VMHost $HostAddress -RescanAllHba 
+            
+            Write-Host "Rescanning Completed."
+
+        }
+       
+        else {
+            Write-Host "No NVMe/TCP controller found on given host " $HostAddress    
+        } 
+    }
+    catch {
+        throw "Failed to execute Get-EsxCli cmdlet on host $($HostAddress). Make sure valid ESXi IP/DNS is provided."
+    } 
+    Write-Host ""
+}


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Create distributed portgroups.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

