### PR TITLE
Get correct esxi from a specified cluster when creating a new datastore

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -181,8 +181,9 @@ function New-VmfsDatastore {
         Write-Host "Creating datastore $DatastoreName..."
 
         $TotalSectors = $SizeInBytes / 512
-        $Esxi = Get-View -ViewType HostSystem | Where-Object { ($_.Runtime.ConnectionState -eq 'connected') } | Select-Object -last 1
-        $DatastoreSystem = Get-View -Id $Esxi.ConfigManager.DatastoreSystem
+        $Esxi = $Cluster | Get-VMHost | Where-Object { ($_.ConnectionState -eq 'Connected') } | Select-Object -last 1
+        $EsxiView = Get-View -ViewType HostSystem -Filter @{"Name" = $Esxi.name}
+        $DatastoreSystem = Get-View -Id $EsxiView.ConfigManager.DatastoreSystem
         $Device = $DatastoreSystem.QueryAvailableDisksForVmfs($null) | Where-Object { ($_.CanonicalName -eq $DeviceNaaId) }
         $DatastoreCreateOptions = $DatastoreSystem.QueryVmfsDatastoreCreateOptions($Device.DevicePath, $null)
 


### PR DESCRIPTION
Motivation: When creating a new datastore, the correct esxi from a specified cluster should be used. Otherwise, the run command might fail to find the storage device

Testing: Pester tests using local Vmware deployment

This PR closes #

The changes in this PR are as follows:

* ...
* ...
* ...

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

