### PR TITLE
Enabling cmdlet to remove a VMFS datastore from given vSphere Cluster

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -77,7 +77,8 @@
         "Sync-ClusterVMHostStorage",
         "Remove-VMHostStaticIScsiTargets",
         "Connect-NVMeTCPTarget",
-        "Disconnect-NVMeTCPTarget"
+        "Disconnect-NVMeTCPTarget",
+        "Remove-VmfsDatastore"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
This PR enables user to remove a specified VMFS datastore from a given vSphere Cluster, datastore is removed and esxi host wouldn't not be able to access that datastore, mentioned by user. 

The changes in this PR are as follows:

* Enable RunCommand to remove a VMFS datastore. 
*  A shared datastore across vSphere clusters is not removed, only unmounted from host(s) under given vSphere cluster.
* A datastore is not removed if it has any worker virtual machine.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

