### PR TITLE
Add attribute to specify whether a script is intended to be for automation

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -8,11 +8,13 @@
 AVSAttribute applied to a commandlet function indicates:
 - whether the SDDC should be marked as Building while the function executes.
 - default timeout for the commandlet, maximum: 3h.
+- whether a commandlet is intended to be only for automation or is visible to all customers.
 AVS SDDC in Building state prevents other changes from being made to the SDDC until the function completes/fails.
 #>
 class AVSAttribute : Attribute {
     [bool]$UpdatesSDDC = $false
     [TimeSpan]$Timeout
+    [bool]$IsAutomation = $false
     AVSAttribute($timeoutMinutes) { $this.Timeout = New-TimeSpan -Minutes $timeoutMinutes }
 }
 

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -14,7 +14,7 @@ AVS SDDC in Building state prevents other changes from being made to the SDDC un
 class AVSAttribute : Attribute {
     [bool]$UpdatesSDDC = $false
     [TimeSpan]$Timeout
-    [bool]$IsAutomation = $false
+    [bool]$AutomationOnly = $false
     AVSAttribute($timeoutMinutes) { $this.Timeout = New-TimeSpan -Minutes $timeoutMinutes }
 }
 

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -25,7 +25,7 @@ using module Microsoft.AVS.Management
 #>
 function Set-VmfsIscsi {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -121,7 +121,7 @@ function Set-VmfsIscsi {
 #>
 function New-VmfsDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -231,7 +231,7 @@ function New-VmfsDatastore {
 #>
 function Dismount-VmfsDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -305,7 +305,7 @@ function Dismount-VmfsDatastore {
 #>
 function Resize-VmfsVolume {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -382,7 +382,7 @@ function Resize-VmfsVolume {
 #>
 function Restore-VmfsVolume {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -493,7 +493,7 @@ function Restore-VmfsVolume {
 #>
 function Sync-VMHostStorage {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
                 Mandatory=$true,
@@ -524,7 +524,7 @@ function Sync-VMHostStorage {
 #>
 function Sync-ClusterVMHostStorage {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
                 Mandatory=$true,
@@ -563,7 +563,7 @@ function Sync-ClusterVMHostStorage {
 #>
 function Remove-VMHostStaticIScsiTargets {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
                 Mandatory=$true,
@@ -647,7 +647,7 @@ function Remove-VMHostStaticIScsiTargets {
 #>
 function Connect-NVMeTCPTarget {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param
     (
         [Parameter(
@@ -791,7 +791,7 @@ function Connect-NVMeTCPTarget {
 #>
 function Disconnect-NVMeTCPTarget {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
 
     Param
     (

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -25,7 +25,7 @@ using module Microsoft.AVS.Management
 #>
 function Set-VmfsIscsi {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -121,7 +121,7 @@ function Set-VmfsIscsi {
 #>
 function New-VmfsDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -231,7 +231,7 @@ function New-VmfsDatastore {
 #>
 function Dismount-VmfsDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -305,7 +305,7 @@ function Dismount-VmfsDatastore {
 #>
 function Resize-VmfsVolume {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -382,7 +382,7 @@ function Resize-VmfsVolume {
 #>
 function Restore-VmfsVolume {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
             Mandatory=$true,
@@ -493,7 +493,7 @@ function Restore-VmfsVolume {
 #>
 function Sync-VMHostStorage {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
                 Mandatory=$true,
@@ -524,7 +524,7 @@ function Sync-VMHostStorage {
 #>
 function Sync-ClusterVMHostStorage {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
                 Mandatory=$true,
@@ -563,7 +563,7 @@ function Sync-ClusterVMHostStorage {
 #>
 function Remove-VMHostStaticIScsiTargets {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param (
         [Parameter(
                 Mandatory=$true,
@@ -647,7 +647,7 @@ function Remove-VMHostStaticIScsiTargets {
 #>
 function Connect-NVMeTCPTarget {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
     Param
     (
         [Parameter(
@@ -791,7 +791,7 @@ function Connect-NVMeTCPTarget {
 #>
 function Disconnect-NVMeTCPTarget {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, IsAutomation = $true)]
 
     Param
     (

--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ Secrets and additional attributes:
 - Use `PSCredential` and `SecureString` if taking credentials or secrets as inputs. These parameters are encrypted while inflight and at rest and will never be echoed back to the user.
 - The functions and parameters must have user-friendly description, using standard PS facilities.
 - All names must follow PowerShell [naming guidelines](https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/required-development-guidelines?view=powershell-7.3#use-only-approved-verbs-rd01).
-- Apply `AVSAttribute` as show in [this example](https://www.powershellgallery.com/packages/Microsoft.AVS.Management/1.0.31/Content/Microsoft.AVS.Management.psm1) to specify the default timeout and SDDC status for your scripts.
+- Apply `AVSAttribute` as show in [this example](https://www.powershellgallery.com/packages/Microsoft.AVS.Management/1.0.31/Content/Microsoft.AVS.Management.psm1) to specify the default timeout, SDDC status and whether it is intended to be invoked only through automation for your scripts.
 
 Other supported parameter types:
 - `System.String`


### PR DESCRIPTION
The changes in this PR are as follows:

* Add a new AVSAttribute to differentiate between automation scripts or is visible to customers.
* Modify existing cmdlets in Microsoft.AVS.VMFS to use the new property.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

