### PR TITLE
Enable user to  Mount VMFS datastore on all ESXi host(s) under a vSphere cluster

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -78,7 +78,8 @@
         "Remove-VMHostStaticIScsiTargets",
         "Connect-NVMeTCPTarget",
         "Disconnect-NVMeTCPTarget",
-        "Remove-VmfsDatastore"
+        "Remove-VmfsDatastore",
+        "Mount-VmfsDatastore"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -890,8 +890,7 @@ function Disconnect-NVMeTCPTarget {
 
     .PARAMETER DatastoreName
      Datastore Name
-    
-    
+     
     .EXAMPLE
      Remove-VmfsDatastore -ClusterName "vSphere-cluster-001"  -DatastoreName "datastore-name-01" 
 

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -891,6 +891,7 @@ function Disconnect-NVMeTCPTarget {
     .PARAMETER DatastoreName
      Datastore Name
     
+    
     .EXAMPLE
      Remove-VmfsDatastore -ClusterName "vSphere-cluster-001"  -DatastoreName "datastore-name-01" 
 

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -890,7 +890,8 @@ function Disconnect-NVMeTCPTarget {
 
     .PARAMETER DatastoreName
      Datastore Name
-     
+
+    
     .EXAMPLE
      Remove-VmfsDatastore -ClusterName "vSphere-cluster-001"  -DatastoreName "datastore-name-01" 
 


### PR DESCRIPTION
This PR will enable user to mount a datastore on all ESXi host(s) under a given cluster, in certain cases a new esxi host is added to vSphere cluster OR an already UNMOUNTED datastore is required to be brought back to hosts in the vSphere cluster. 

This PR includes changes as follow:

* Mount a given VMFS datastore to all host(s) in the vSphere cluster.
* Backing device (volume) iSCSI or NVMe/TCP  is identified for the given datastore.
* Mounting is skipped on host(s) with no access to volume(device) that was used as backing device for the datastore. 


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

