### PR TITLE
Enable user to collect all available VMFS datastores under a given vSphere Cluster 

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -79,7 +79,8 @@
         "Connect-NVMeTCPTarget",
         "Disconnect-NVMeTCPTarget",
         "Remove-VmfsDatastore",
-        "Mount-VmfsDatastore"
+        "Mount-VmfsDatastore",
+        "Get-VmfsDatastore"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1097,8 +1097,6 @@ function Mount-VmfsDatastore {
 <#
     .SYNOPSIS
      This function list all VMFS datastores accessible to host(s) under the given ESXi Cluster.
-
-     1. vSphere Cluster Name
           
     .PARAMETER ClusterName
      vSphere Cluster Name
@@ -1149,20 +1147,30 @@ function Get-VmfsDatastore {
       
     }
 
-    foreach ($Datastore in $Datastores){
+    $NamedOutputs = @{}
 
+    foreach ($Datastore in $Datastores){
       $VmfsUuid = $Datastore.ExtensionData.info.Vmfs.uuid 
       $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname;
-      
-      Write-Output "Name : $($Datastore.Name)"
-      Write-Output "Capacity(GB) : $($Datastore.CapacityGB)"
-      Write-Output "FreeSpace(GB) : $($Datastore.FreeSpaceGB)"
-      Write-Output "Type : $($Datastore.Type)"
-      Write-Output "UUID : $($VmfsUuid)"
-      Write-Output "Device : $($HostViewDiskName)"      
-      Write-Output "State : $($Datastore.State)"      
-      Write-Host "  "  
+      $NamedOutputs[$Datastore.Name] = "
+           { 
+           Name : $($Datastore.Name),
+           Capacity : $($Datastore.CapacityGB),
+           FreeSpace : $($Datastore.FreeSpaceGB), 
+           Type : $($Datastore.Type),
+           UUID : $($VmfsUuid),
+           Device : $($HostViewDiskName),      
+           State : $($Datastore.State),      
+           }"
     }
   
+   if($NamedOutputs.Count -gt 0){
+  
+      Write-host $NamedOutputs | ConvertTo-Json -Depth 10
+   }
+
+   Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+
+   Write-Host " "
      
 }

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -261,7 +261,7 @@ function Dismount-VmfsDatastore {
         throw "Datastore $DatastoreName is of type $($Datastore.Type). This cmdlet can only process VMFS datastores."
     }
 
-    Write-Host "Unmounting datastore $DatastoreName from all hosts and detaching the SCSI device associated with it..."
+    Write-Host "Unmounting datastore $DatastoreName from all hosts, detaching SCSI devices, NVMe/TCP devices are not detached."
     $VMHosts = $Cluster | Get-VMHost
     foreach ($VMHost in $VMHosts) {
         $IsDatastoreConnectedToHost = Get-Datastore -VMHost $VMHost | Where-Object {$_.name -eq $DatastoreName}
@@ -278,7 +278,16 @@ function Dismount-VmfsDatastore {
             $HostStorageSystem = Get-View $VMHost.Extensiondata.ConfigManager.StorageSystem
 
             $HostStorageSystem.UnmountVmfsVolume($VmfsUuid) | Out-Null
-            $HostStorageSystem.DetachScsiLun($ScsiLunUuid) | Out-Null
+            Write-Host "Datastore unmounted."
+
+            $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname;
+            if(($null -ne $HostViewDiskName) -and ($HostViewDiskName.StartsWith("eui."))){
+               Write-Host "Device UUID $($VmfsUuid) is an NVMe/TCP volume, not required to be detached, and can be mounted back to host as needed."  
+            }
+            else {
+                  $HostStorageSystem.DetachScsiLun($ScsiLunUuid) | Out-Null
+            }      
+            Write-Host "Rescanning now.."
             $VMHost | Get-VMHostStorage -RescanAllHba -RescanVmfs | Out-Null
         }
     }
@@ -1083,3 +1092,77 @@ function Mount-VmfsDatastore {
     }
                
   }
+
+
+<#
+    .SYNOPSIS
+     This function list all VMFS datastores accessible to host(s) under the given ESXi Cluster.
+
+     1. vSphere Cluster Name
+          
+    .PARAMETER ClusterName
+     vSphere Cluster Name
+    
+    .EXAMPLE
+     Get-VmfsDatastore -ClusterName "vSphere-cluster-001"  
+
+    .INPUTS
+     vSphere Cluster Name
+
+    .OUTPUTS
+     None.
+#>
+
+function Get-VmfsDatastore {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+   
+    Param
+    (
+      [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'vSphere Cluster Name')]
+      [string] $ClusterName
+
+    )
+       
+    Write-Host "Collecting all available VMFS datastores accessible to ESXi host(s) in the cluster "  $ClusterName
+    Write-Host ""    
+    $ClusterName = $ClusterName.Trim()
+
+    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
+    if (-not $Cluster) {
+        throw "Cluster $($ClusterName) does not exist."
+    }
+
+    $VmHosts = $Cluster | Get-VMHost -ErrorAction Ignore 
+    if (-not $VmHosts) {
+        throw "No ESXi host found under $($ClusterName)."
+    }
+
+
+    $Datastores = Get-VMHost -Name $VmHosts | Get-Datastore | Where-Object {$_.Type -match "VMFS"} | Get-Unique
+
+    if ( -not $Datastores) {
+        Write-Host "No Datastore found under the given cluster."
+        return
+      
+    }
+
+    foreach ($Datastore in $Datastores){
+
+      $VmfsUuid = $Datastore.ExtensionData.info.Vmfs.uuid 
+      $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname;
+      
+      Write-Output "Name : $($Datastore.Name)"
+      Write-Output "Capacity(GB) : $($Datastore.CapacityGB)"
+      Write-Output "FreeSpace(GB) : $($Datastore.FreeSpaceGB)"
+      Write-Output "Type : $($Datastore.Type)"
+      Write-Output "UUID : $($VmfsUuid)"
+      Write-Output "Device : $($HostViewDiskName)"      
+      Write-Output "State : $($Datastore.State)"      
+      Write-Host "  "  
+    }
+  
+     
+}


### PR DESCRIPTION
This PR will enable user to know all available datastores under a given cluster.  In many cases end-user of the  RunCommand wants to know the existing datastore and its capacity vs available space. This PR also introduce a change to existing Dismount-datastore for NVMe/TCP devices, current behavior is PRESERVED for scsi devices, and NVMe/TCP devices are not detached after Dismount command similar to other VMware API and vSpher WebUI. 

The changes in this PR are as follows:

*  Get all available datastores under a given vSphere Cluster.
* Dismount will not detach NVMe/TCP devices from ESXi host similar to VMware Unmount using WebIU and mgmt SDK. 


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

