### PR TITLE
use correct dependency for automation designation

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.2.39" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.3.83" }
     )
 
     # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
This PR fixes dependency problem, referencing the package that defines automation property in AVSAttribute.

