### PR TITLE
Enable user to collect detailed Inventory of ESXi host(s) in a given vSphere cluster  

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -80,7 +80,8 @@
         "Disconnect-NVMeTCPTarget",
         "Remove-VmfsDatastore",
         "Mount-VmfsDatastore",
-        "Get-VmfsDatastore"
+        "Get-VmfsDatastore",
+        "Get-VmfsHosts"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
This PR will enable user to collect detailed inventory of all ESXi host(s) in a given vSphere cluster, this PR also let user know the current storage and network configuration and installed ESXi version. As user I want to know my Connection and health status of any esxi host before any datastore operation is invoked on the target host in vCenter. 

The changes in this PR are as follows:

*  Collect detailed ESXi host inventory. 
*  Know the Connection State and Health Status of the host
*  Know  accessible datastore(s) to each ESXi host in the given cluster 
*  Know Storage Adapter (hbas) of a host. 

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

