### PR TITLE
Enable user to  collect and create storage adapter,  Tag VMKernel for NVMe/TCP services. 

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -81,7 +81,11 @@
         "Remove-VmfsDatastore",
         "Mount-VmfsDatastore",
         "Get-VmfsDatastore",
-        "Get-VmfsHosts"
+        "Get-VmfsHosts",
+        "Get-StorageAdapters",
+        "Get-VmKernels",
+        "New-NVMeTCPAdapter",
+        "New-NVMeTCPAdapter"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
This PR will enable user to collect inventory for available storage adapters and VMKernel adapters in the environment, this inventory collection process will help user to know details about each storage and kernel adapter if a new adapter is required for the storage services. User can use the additional command to Tag a VMkernel adapter for NVMe/TCP services and create a storage adapter using one of the physical NIC. 


The changes in this PR are as follows:

*  Collect detail inventory of available storage adapters in the environment.
*  Collect detail inventory of available VMkernel adapters in the environment.
*  Tag a VMkernel Adapter for NVMe/TCP services.
*  Create a storage adapter using one of the physical NIC for upload link.


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

