### PR TITLE
Add VMFS cmdlet exports again

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -75,7 +75,13 @@
         "Restore-VmfsVolume",
         "Sync-VMHostStorage",
         "Sync-ClusterVMHostStorage",
-        "Remove-VMHostStaticIScsiTargets"
+        "Remove-VMHostStaticIScsiTargets",
+        "Connect-NVMeTCPTarget",
+        "Disconnect-NVMeTCPTarget",
+        "Remove-VmfsDatastore",
+        "Mount-VmfsDatastore",
+        "Get-VmfsDatastore",
+        "Get-VmfsHosts"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
The changes in this PR are as follows:

* Adds the export functions back to the VMFS package.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

