### PR TITLE
Removing storage adapter health status check during the process of connecting to targets

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -739,7 +739,7 @@ function Connect-NVMeTCPTarget {
 
         foreach ($StorageAdapter in $StorageAdapters) {
 
-            if (($StorageAdapter.Status -eq "online") -and ($StorageAdapter.Driver -eq "nvmetcp")) {
+            if (($StorageAdapter.Driver -eq "nvmetcp")) {
 
                 if ($HostEsxcli) {
                     $Name = $StorageAdapter.Name.ToString().Trim()


### PR DESCRIPTION
This PR removes a hard check for the health status of the storage adapter, code were skipping to connect adapter with health 
 status unknow,  but not we ignore the health status check and connect adapter to targets. 

The changes in this PR are as follows:

* Remove a health status check during the process of connecting to targets. 

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

