### PR TITLE
Add RunCommand functions to support vVols

### DIFF
--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
@@ -1,5 +1,5 @@
 #
-# Module manifest for module 'Microsoft.AVS.VMFS'
+# Module manifest for module 'Microsoft.AVS.VVOLS'
 #
 
 @{
@@ -26,7 +26,7 @@
     Copyright         = ''
 
     # Description of the functionality provided by this module
-    Description       = 'Azure VMware Solutions VMFS Package (Automation only).'
+    Description       = 'Azure VMware Solutions VVOLS Package.'
 
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.2.39" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.3.88" }
     )
 
     # Assemblies that must be loaded prior to importing this module
@@ -81,7 +81,7 @@
     CmdletsToExport   = @()
 
     # Variables to export from this module
-    VariablesToExport = '*'
+    VariablesToExport = ''
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
     AliasesToExport   = @()

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
@@ -1,0 +1,136 @@
+#
+# Module manifest for module 'Microsoft.AVS.VMFS'
+#
+
+@{
+
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'Microsoft.AVS.VVOLS.psm1'
+
+    # Version number of this module.
+    ModuleVersion = '1.0.0'
+
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
+
+    # ID used to uniquely identify this module
+    GUID = '5fa1a15b-4953-4eba-9d69-1cf8d7a94f70'
+
+    # Author of this module
+    Author = ''
+
+    # Company or vendor of this module
+    CompanyName = ''
+
+    # Copyright statement for this module
+    Copyright = ''
+
+    # Description of the functionality provided by this module
+    Description = 'Azure VMware Solutions VMFS Package (Automation only).'
+
+    # Minimum version of the PowerShell engine required by this module
+    PowerShellVersion = '5.1'
+
+    # Name of the PowerShell host required by this module
+    # PowerShellHostName = ''
+
+    # Minimum version of the PowerShell host required by this module
+    # PowerShellHostVersion = ''
+
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
+
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # ClrVersion = ''
+
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules = @(
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.2.39" }
+    )
+
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
+
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
+
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
+
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
+
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = @(
+        "New-VvolDatastore",
+        “Remove-VvolDatastore”,
+        "New-VvolVasaProvider",
+        "Update-VMHostCertificate",
+        "Remove-VvolVasaProvider",
+        "New-VvolStoragePolicy",
+        "Remove-VvolStoragePolicy"
+    )
+
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = @()
+
+    # Variables to export from this module
+    VariablesToExport = '*'
+
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = @()
+
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
+
+    # List of all modules packaged with this module
+    # ModuleList = @()
+
+    # List of all files packaged with this module
+    # FileList = @()
+
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
+
+    #Support for PowerShellGet galleries.
+        PSData = @{
+        # Tags applied to this module. These help with module discovery in online galleries.
+            Tags = @("VMware", "PowerCLI", "Azure", "AVS")
+
+            # A URL to the license for this module.
+            # LicenseUri = ''
+
+            # A URL to the main website for this project.
+            ProjectUri = 'https://github.com/Azure/Microsoft.AVS.Management'
+
+            # A URL to an icon representing this module.
+            # IconUri = ''
+
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
+
+            # Remove this for GA version
+            # Prerelease = ''
+
+            # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+            # RequireLicenseAcceptance = $false
+
+            # External dependent modules of this module
+            # ExternalModuleDependencies = @()
+        }
+
+    }
+
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
+
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
+
+}

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
@@ -5,28 +5,28 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule = 'Microsoft.AVS.VVOLS.psm1'
+    RootModule        = 'Microsoft.AVS.VVOLS.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.0'
+    ModuleVersion     = '1.0.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
 
     # ID used to uniquely identify this module
-    GUID = '5fa1a15b-4953-4eba-9d69-1cf8d7a94f70'
+    GUID              = '5fa1a15b-4953-4eba-9d69-1cf8d7a94f70'
 
     # Author of this module
-    Author = ''
+    Author            = ''
 
     # Company or vendor of this module
-    CompanyName = ''
+    CompanyName       = ''
 
     # Copyright statement for this module
-    Copyright = ''
+    Copyright         = ''
 
     # Description of the functionality provided by this module
-    Description = 'Azure VMware Solutions VMFS Package (Automation only).'
+    Description       = 'Azure VMware Solutions VMFS Package (Automation only).'
 
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'
@@ -47,7 +47,7 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules = @(
+    RequiredModules   = @(
         @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.2.39" }
     )
 
@@ -78,13 +78,13 @@
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-    CmdletsToExport = @()
+    CmdletsToExport   = @()
 
     # Variables to export from this module
     VariablesToExport = '*'
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport = @()
+    AliasesToExport   = @()
 
     # DSC resources to export from this module
     # DscResourcesToExport = @()
@@ -96,12 +96,12 @@
     # FileList = @()
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-    PrivateData = @{
+    PrivateData       = @{
 
-    #Support for PowerShellGet galleries.
+        #Support for PowerShellGet galleries.
         PSData = @{
-        # Tags applied to this module. These help with module discovery in online galleries.
-            Tags = @("VMware", "PowerCLI", "Azure", "AVS")
+            # Tags applied to this module. These help with module discovery in online galleries.
+            Tags       = @("VMware", "PowerCLI", "Azure", "AVS")
 
             # A URL to the license for this module.
             # LicenseUri = ''

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -254,7 +254,7 @@ function Remove-VvolVasaProvider {
 
     $VasaProvider = Get-VasaProvider -Name $ProviderName -ErrorAction Ignore
     if (-not $VasaProvider) {
-        throw "Unable to remove a VASA provider. Vasa provider '$ProviderName' does not exist."
+        throw "Unable to remove a VASA provider '$ProviderName'. Vasa provider '$ProviderName' does not exist."
     }
 
     # Find datastores connected to the vasa provider
@@ -312,6 +312,9 @@ function New-VvolStoragePolicy {
     # Extract values from the object
     $Vendor = $PolicyConfig.Vendor
     $PolicyName = $PolicyConfig.PolicyName
+    if (-not $PolicyName) {
+        throw "Unable to create a storage policy. Policy name is not specified."
+    }
     $PolicyDescription = $PolicyConfig.PolicyDescription
     $SchemaVersion = $PolicyConfig.SchemaVersion
 
@@ -376,4 +379,3 @@ function Remove-VvolStoragePolicy {
     Write-Host "Removing policy $PolicyName..."
     Remove-SpbmStoragePolicy -StoragePolicy $Policy -Confirm:$false -ErrorAction Stop | Out-Null
 }
-

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -1,0 +1,371 @@
+using module Microsoft.AVS.Management
+
+<#
+    .SYNOPSIS
+     Creates a new vVol datastore and mounts to a VMware cluster.
+
+    .PARAMETER ClusterName
+     Cluster name
+
+    .PARAMETER DatastoreName
+     Datastore name
+
+    .PARAMETER ScId
+     Storage container ID of device used to create a new vVol datastore
+
+    .EXAMPLE
+     New-VVolDatastore -ClusterName "myCluster" -DatastoreName "myDatastore" -ScId $ScId
+
+    .INPUTS
+     vCenter cluster name, datastore name, and storage container ID
+
+    .OUTPUTS
+     None.
+#>
+function New-VvolDatastore {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param (
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Cluster name in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $ClusterName,
+
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Name of vVol datastore to be created in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $DatastoreName,
+
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Storage container ID of device used to create a new vVol datastore')]
+        [ValidateNotNull()]
+        [String]
+        $ScId
+    )
+
+    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
+    if (-not $Cluster) {
+        throw "Cluster $ClusterName does not exist."
+    }
+
+    $Datastore = Get-Datastore -Name $DatastoreName -ErrorAction Ignore
+    if ($Datastore) {
+        throw "Unable to create a datastore. Datastore '$DatastoreName' already exists."
+    }
+    $VMHosts = $Cluster | Get-VMHost
+    # We need to loop through Esxi to mount the datastore to all of hosts
+    foreach ($Esxi in $VMHosts) {
+        # Create a new vVol datastore with the specified size and rescan storage
+        $datastoreSystem = Get-View -Id $Esxi.ExtensionData.ConfigManager.DatastoreSystem
+        $spec = New-Object VMware.Vim.HostDatastoreSystemVvolDatastoreSpec
+        $spec.Name = $datastoreName
+        $spec.ScId = $scId
+        $Datastore = $esxi | Get-Datastore | Where-Object {$_.Type -eq "VVol"} | Where-Object { $_.ExtensionData.Info.VVolds.Scid -eq $scId }
+        Write-Host "Mounting datastore $DatastoreName to host $($Esxi.Name)..."
+        $datastoreSystem.CreateVvolDatastore($spec)
+    }
+}
+
+
+<#
+    .SYNOPSIS
+     Removes a vVol datastore from a VMware cluster.
+
+    .PARAMETER ClusterName
+     Cluster name
+
+    .PARAMETER DatastoreName
+     Datastore name
+
+    .EXAMPLE
+     Remove-VVolDatastore -ClusterName "myCluster" -DatastoreName "myDatastore"
+    
+    .INPUTS
+     vCenter cluster name, datastore name
+
+    .OUTPUTS
+     None.
+#>
+function Remove-VvolDatastore {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param (
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Cluster name in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $ClusterName,
+
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Name of vVol datastore to be created in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $DatastoreName
+    )
+
+    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
+    if (-not $Cluster) {
+        throw "Cluster $ClusterName does not exist."
+    }
+
+    $Datastore = Get-Datastore -Name $DatastoreName -ErrorAction Ignore
+    if (-not $Datastore) {
+        throw "Unable to remove a datastore. Datastore '$DatastoreName' does not exist."
+    }
+
+    if ("VVOL" -ne $Datastore.Type) {
+        throw "Datastore $DatastoreName is of type $($Datastore.Type). This cmdlet can only process VVol datastores"
+    }
+
+    $VMHosts = $Cluster | Get-VMHost
+    # We need to loop through Esxi to unmount the datastore from all of hosts
+    foreach ($Esxi in $VMHosts) {
+        # Unmount the datastore from the host
+        $datastoreSystem = Get-View -Id $Esxi.ExtensionData.ConfigManager.DatastoreSystem
+        Write-Host "Unmounting datastore $DatastoreName from host $($Esxi.Name)..."
+        $datastoreSystem.RemoveDatastore($Datastore.ExtensionData.MoRef)
+    }
+}
+
+
+<#
+    .SYNOPSIS
+    Refresh certificates for all ESXi hosts
+
+    .DESCRIPTION
+    Refresh certificates for all ESXi hosts
+
+    .EXAMPLE
+    Update-VMHostCertificate
+
+    .INPUTS
+    None.
+
+    .OUTPUTS
+    None.
+
+#>
+function Update-VMHostCertificate {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param ()
+
+    $service_instance = Get-View ServiceInstance
+    $certMgr = Get-View -Id $service_instance.Content.CertificateManager
+
+    Get-VMHost | ForEach-Object -Process {
+        Write-Host "Refreshing certificates for $($_.Name).."
+        $certMgr.CertMgrRefreshCACertificatesAndCRLs($_.Id) | Out-Null
+    }
+
+    Write-Host "Certificates refreshed successfully for all of ESXi hosts."
+}
+
+<#
+    .SYNOPSIS
+     Create a new VASA provider in vCenter
+
+    .PARAMETER ProviderName
+     Name of VASA provider to be created in vCenter
+
+    .PARAMETER FlashArrayMgmtIP
+     URL of the VASA provider service
+
+    .PARAMETER ProviderCredential
+     Credential of the VASA provider service
+
+    .EXAMPLE
+     New-VvolVasaProvider -ProviderName "myProvider" -FlashArrayMgmtIP "1.0.0.0" -ProviderCredential $ProviderCredential
+#>
+function New-VvolVasaProvider {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param (
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Name of VASA provider to be created in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $ProviderName,
+
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'URL of the VASA provider service')]
+        [ValidateNotNull()]
+        [String]
+        $ProviderUrl,
+
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Credential of the VASA provider service')]
+        [ValidateNotNull()]
+        [PSCredential]
+        $ProviderCredential
+    )
+
+    $VasaProvider = Get-VasaProvider -Name $ProviderName -ErrorAction Ignore
+    if ($vasaProvider) {
+        throw "Unable to create a VASA provider. Vasa provider '$ProviderName' already exists."
+    }
+
+    New-VasaProvider -Name $ProviderName -Credential $ProviderCredential -Url $ProviderUrl -Force -ErrorAction Stop | Out-Null
+
+    Write-Host "VASA provider $ProviderName created successfully."
+}
+
+<#
+    .SYNOPSIS
+     Remove a VASA provider from vCenter
+
+    .PARAMETER ProviderName
+     Name of VASA provider to be removed from vCenter
+
+    .EXAMPLE
+     Remove-VvolVasaProvider -ProviderName "myProvider"
+
+    .INPUTS
+     vCenter VASA provider name
+
+    .OUTPUTS
+     None.
+#>
+function Remove-VvolVasaProvider {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param (
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Name of VASA provider to be created in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $ProviderName
+    )
+
+    $VasaProvider = Get-VasaProvider -Name $ProviderName -ErrorAction Ignore
+    if (-not $VasaProvider) {
+        throw "Unable to remove a VASA provider. Vasa provider '$ProviderName' does not exist."
+    }
+
+    Remove-VasaProvider -Provider $VasaProvider -Confirm:$false -ErrorAction Stop | Out-Null
+
+    Write-Host "VASA provider $ProviderName removed successfully."
+}
+
+
+<#
+    .SYNOPSIS
+     Creates a new vVol Storage Policy
+
+    .PARAMETER PolicyConfigJsonString
+     Storage policy in Json string. The command will traverse through the SPBM rules and creat a storage policy containing all of the rules.
+     The example string is as below:
+    {
+        "SchemaVersion": "1.0.0",
+        "Vendor": "Pure Storage",
+        "PolicyName": "",
+        "PolicyDescription": "",
+        "SpbmRules": {
+            "com.purestorage.storage.policy.FlashArrayGroup":["fa1","fa2"],
+            "com.purestorage.storage.replication.LocalSnapshotPolicyCapable": true,
+            "com.purestorage.storage.replication.LocalSnapshotInterval":"00:00:00"
+            ...
+        }
+    }
+
+    .EXAMPLE
+     New-VvolStoragePolicy -PolicyConfigJsonString $policyConfigJsonString
+
+    .INPUTS
+     vCenter storage policy in Json string
+
+    .OUTPUTS
+     None.
+#>
+function New-VvolStoragePolicy {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param(
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Storage policy in Json string')]
+        [ValidateNotNull()]
+        [String]$PolicyConfigJsonString
+    )
+    # Convert JSON to PowerShell object
+    $PolicyConfig = ConvertFrom-Json $PolicyConfigJsonString
+    # Extract values from the object
+    $Vendor = $PolicyConfig.Vendor
+    $PolicyName = $PolicyConfig.PolicyName
+    $PolicyDescription = $PolicyConfig.PolicyDescription
+    $SchemaVersion = $PolicyConfig.SchemaVersion
+
+    if ($SchemaVersion -gt "1.0.0") {
+        throw "Unable to create a storage policy. Schema version $SchemaVersion is not supported."
+    }
+
+    # Create SPBM rules dictionary
+    $rules = @()
+    $PolicyConfig.SpbmRules.PSObject.Properties | ForEach-Object {
+        $RuleName = $_.Name
+        $RuleValue = $_.Value
+        if ($Vendor -eq "Pure Storage") {
+            $ValueType = (Get-SpbmCapability -Name $RuleName).ValueType.Name
+            if ($RuleValue -is [int64] -and $ValueType -eq "int32") {
+                $RuleValue = [int]$RuleValue
+            }
+            if ($ValueType -eq "TimeSpan") {
+                $RuleValue = [TimeSpan]::Parse($RuleValue)
+            }
+        }
+        $rules += New-SpbmRule -Capability (Get-SpbmCapability -Name $RuleName) -Value $RuleValue
+    }
+
+    Write-Host "Creating policy $PolicyName for vendor $Vendor..."
+    $Ruleset = New-SpbmRuleSet -AllOfRules $rules
+    New-SpbmStoragePolicy -Name $PolicyName -Description $PolicyDescription -AnyOfRuleSets $Ruleset -ErrorAction Stop | Out-Null
+}
+
+<#
+    .SYNOPSIS
+    Removes a vVol Storage Policy
+
+    .PARAMETER PolicyName
+    Name of the storage policy to be removed
+
+    .EXAMPLE
+    Remove-VvolStoragePolicy -PolicyName "myPolicy"
+
+    .INPUTS
+    vCenter storage policy name
+
+    .OUTPUTS
+    None.
+#>
+function Remove-VvolStoragePolicy {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param(
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Storage policy name')]
+        [ValidateNotNull()]
+        [String]$PolicyName
+    )
+
+    $Policy = Get-SpbmStoragePolicy -Name $PolicyName -ErrorAction Ignore
+    if (-not $Policy) {
+        throw "Unable to remove a storage policy. Storage policy '$PolicyName' does not exist."
+    }
+
+    Write-Host "Removing policy $PolicyName..."
+    Remove-SpbmStoragePolicy -StoragePolicy $Policy -Confirm:$false -ErrorAction Stop | Out-Null
+}
+  
+  

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -27,21 +27,21 @@ function New-VvolDatastore {
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Name of vVol datastore to be created in vCenter')]
         [ValidateNotNull()]
         [String]
         $DatastoreName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Storage container ID of device used to create a new vVol datastore')]
         [ValidateNotNull()]
         [String]
@@ -65,7 +65,7 @@ function New-VvolDatastore {
         $spec = New-Object VMware.Vim.HostDatastoreSystemVvolDatastoreSpec
         $spec.Name = $datastoreName
         $spec.ScId = $scId
-        $Datastore = $esxi | Get-Datastore | Where-Object {$_.Type -eq "VVol"} | Where-Object { $_.ExtensionData.Info.VVolds.Scid -eq $scId }
+        $Datastore = $esxi | Get-Datastore | Where-Object { $_.Type -eq "VVol" } | Where-Object { $_.ExtensionData.Info.VVolds.Scid -eq $scId }
         Write-Host "Mounting datastore $DatastoreName to host $($Esxi.Name)..."
         $datastoreSystem.CreateVvolDatastore($spec)
     }
@@ -84,7 +84,7 @@ function New-VvolDatastore {
 
     .EXAMPLE
      Remove-VVolDatastore -ClusterName "myCluster" -DatastoreName "myDatastore"
-    
+
     .INPUTS
      vCenter cluster name, datastore name
 
@@ -96,14 +96,14 @@ function Remove-VvolDatastore {
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Name of vVol datastore to be created in vCenter')]
         [ValidateNotNull()]
         [String]
@@ -189,21 +189,21 @@ function New-VvolVasaProvider {
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Name of VASA provider to be created in vCenter')]
         [ValidateNotNull()]
         [String]
         $ProviderName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'URL of the VASA provider service')]
         [ValidateNotNull()]
         [String]
         $ProviderUrl,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Credential of the VASA provider service')]
         [ValidateNotNull()]
         [PSCredential]
@@ -241,7 +241,7 @@ function Remove-VvolVasaProvider {
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Name of VASA provider to be created in vCenter')]
         [ValidateNotNull()]
         [String]
@@ -293,7 +293,7 @@ function New-VvolStoragePolicy {
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param(
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Storage policy in Json string')]
         [ValidateNotNull()]
         [String]$PolicyConfigJsonString
@@ -353,7 +353,7 @@ function Remove-VvolStoragePolicy {
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param(
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Storage policy name')]
         [ValidateNotNull()]
         [String]$PolicyName
@@ -367,5 +367,4 @@ function Remove-VvolStoragePolicy {
     Write-Host "Removing policy $PolicyName..."
     Remove-SpbmStoragePolicy -StoragePolicy $Policy -Confirm:$false -ErrorAction Stop | Out-Null
 }
-  
-  
+


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:
Add functions to:
- create and remove datastores
- register VASA provider
- add storage policies

Testing: Unit tests using Pester running on on-premise VMWare instances

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC. 
          >  Not possible before deploying to Azure.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

