### PR TITLE
Add RunCommands for failover management.

### DIFF
--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
@@ -74,7 +74,11 @@
         "Update-VMHostCertificate",
         "Remove-VvolVasaProvider",
         "New-VvolStoragePolicy",
-        "Remove-VvolStoragePolicy"
+        "Remove-VvolStoragePolicy",
+        "Start-ReplicationFailover",
+        "Stop-ReplicationTestFailover",
+        "Start-ReplicationReverse",
+        "Sync-ReplicationGroup"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -390,6 +390,9 @@ function Remove-VvolStoragePolicy {
     .PARAMETER TestFailover
     Optional. Indicates whether to actually perform a failover(false) or to only perform a test failover(true). If not provided will only perform failover test.
 
+    .PARAMETER PointInTimeReplicaName
+    Optional. Point-in-time replica name. If not provided, the latest point-in-time replica will be used.
+
     .EXAMPLE
     Start-ReplicationFailover -ReplicationGroupID "myRepGroupID" -TestFailover $true
 
@@ -541,10 +544,10 @@ function Start-ReplicationReverse {
     }
 
     Write-Host "Starting reverse replication for replication group $ReplicationGroupID..."
-    $new_source_group = Start-SpbmReplicationReverse -ReplicationGroup $repGroup.Name
+    $newSourceGroup = Start-SpbmReplicationReverse -ReplicationGroup $repGroup.Name
 
     $NamedOutputs = @{}
-    $NamedOutputs["new_source_group"] = $new_source_group.Name
+    $NamedOutputs["new_source_group"] = $newSourceGroup.Name
     Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
 }
 
@@ -556,10 +559,10 @@ function Start-ReplicationReverse {
     Replication group ID
 
     .PARAMETER PointInTimeReplicaName
-    Optional. Point-in-time replica name. If not provided, the latest point-in-time replica will be used.
+    Point-in-time replica name. If not provided, the latest point-in-time replica will be used.
 
     .EXAMPLE
-    Sync-ReplicationGroup -ReplicationGroupID "myRepGroupID"
+    Sync-ReplicationGroup -ReplicationGroupID "myRepGroupID" -PointInTimeReplicaName "myReplica"
 
     .INPUTS
     Replication Group ID

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -379,3 +379,219 @@ function Remove-VvolStoragePolicy {
     Write-Host "Removing policy $PolicyName..."
     Remove-SpbmStoragePolicy -StoragePolicy $Policy -Confirm:$false -ErrorAction Stop | Out-Null
 }
+
+<#
+    .SYNOPSIS
+    Start a Replication Group failover or test failover
+
+    .PARAMETER ReplicationGroupID
+    Replication group ID
+
+    .PARAMETER TestFailover
+    Optional. Indicates whether to actually perform a failover(false) or to only perform a test failover(true). If not provided will only perform failover test.
+
+    .EXAMPLE
+    Start-ReplicationFailover -ReplicationGroupID "myRepGroupID" -TestFailover $true
+
+    .INPUTS
+    Replication Group ID
+
+    .OUTPUTS
+    Replicated Virtual Machine names.
+#>
+function Start-ReplicationFailover {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param(
+        [Parameter(
+                Mandatory = $true,
+                HelpMessage = 'Replication group ID')]
+        [ValidateNotNull()]
+        [String] $ReplicationGroupID,
+
+        [Parameter(
+                mandatory = $false,
+                HelpMessage = 'Point-in-time replica name')]
+        [String] $PointInTimeReplicaName,
+
+        [Parameter(
+                mandatory = $false,
+                HelpMessage = 'Whether to perform a test failover or not')]
+        [bool] $TestFailover
+    )
+    $repGroup = Get-SpbmReplicationGroup -ID $ReplicationGroupID
+
+    if (-not $repGroup) {
+        throw "Could not find replication group '$ReplicationGroupID'."
+    }
+    elseif ($repGroup.State -ne "Target") {
+        throw "Replication group '$ReplicationGroupID' need to be a replication group in 'Target' state."
+    }
+
+    if ($PointInTimeReplicaName) {
+        $replica = Get-SpbmPointInTimeReplica -Name $PointInTimeReplicaName -ErrorAction Ignore
+        if (-not $replica) {
+            throw "Could not find point-in-time replica '$PointInTimeReplicaName'."
+        }
+    }
+
+    ## Failing over the replication group for the VMs and setting the operations to a variable ##
+    if ($TestFailover) {
+        # does test failover, rep group status become InTest
+        Write-Host "Starting test failover for replication group $ReplicationGroupID..."
+        if ($PointInTimeReplicaName) {
+            $replicatedVMFiles = Start-SpbmReplicationTestFailover -ReplicationGroup $repGroup -PointInTimeReplica $replica -Confirm:$false
+        }
+        else {
+            $replicatedVMFiles = Start-SpbmReplicationTestFailover -ReplicationGroup $repGroup -Confirm:$false
+        }
+    }
+    else {
+        # does actual failover, rep group status become FailedOver
+        Write-Host "Starting failover for replication group $ReplicationGroupID..."
+        if ($PointInTimeReplicaName) {
+            $replicatedVMFiles = Start-SpbmReplicationFailover -ReplicationGroup $repGroup -PointInTimeReplica $replica -Confirm:$false
+        }
+        else {
+            $replicatedVMFiles = Start-SpbmReplicationFailover -ReplicationGroup $repGroup -Confirm:$false
+        }
+    }
+
+    $NamedOutputs = @{}
+    $i = 0
+    foreach ($VMFile in $replicatedVMFiles) {
+        $NamedOutputs["vm_$i"] = $VMFile
+    }
+
+    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+}
+
+<#
+    .SYNOPSIS
+    Stop a Replication Group test failover
+
+    .PARAMETER ReplicationGroupID
+    Replication group ID
+
+    .EXAMPLE
+    Stop-ReplicationTestFailover -ReplicationGroupID "myRepGroupID"
+
+    .INPUTS
+    Replication Group ID
+
+    .OUTPUTS
+    None.
+#>
+function Stop-ReplicationTestFailover {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param(
+        [Parameter(
+                Mandatory = $true,
+                HelpMessage = 'Replication group ID')]
+        [ValidateNotNull()]
+        [String]$ReplicationGroupID
+    )
+    $repGroup = Get-SpbmReplicationGroup -ID $ReplicationGroupID
+
+    if (-not $repGroup) {
+        throw "Could not find replication group '$ReplicationGroupID'."
+    }
+    elseif ($repGroup.State -ne "InTest") {
+        throw "Replication group '$ReplicationGroupID' need to be a replication group in 'InTest' state."
+    }
+
+    Write-Host "Stopping test failover for replication group $ReplicationGroupID..."
+    Stop-SpbmReplicationTestFailover -ReplicationGroup $repGroup -Confirm:$false
+}
+
+<#
+    .SYNOPSIS
+    Start a Replication Group reverse
+
+    .PARAMETER ReplicationGroupID
+    Replication group ID
+
+    .EXAMPLE
+    Start-ReplicationReverse -ReplicationGroupID "myRepGroupID"
+
+    .INPUTS
+    Replication Group ID
+
+    .OUTPUTS
+    Reversed Replication Group Name.
+#>
+function Start-ReplicationReverse {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param(
+        [Parameter(
+                Mandatory = $true,
+                HelpMessage = 'Replication group ID')]
+        [ValidateNotNull()]
+        [String]$ReplicationGroupID
+    )
+    $repGroup = Get-SpbmReplicationGroup -ID $ReplicationGroupID
+
+    if (-not $repGroup) {
+        throw "Could not find replication group '$ReplicationGroupID'."
+    }
+    elseif ($repGroup.State -ne "FailedOver") {
+        throw "Replication group '$ReplicationGroupID' need to be a replication group in 'FailedOver' state."
+    }
+
+    Write-Host "Starting reverse replication for replication group $ReplicationGroupID..."
+    $new_source_group = Start-SpbmReplicationReverse -ReplicationGroup $repGroup.Name
+
+    $NamedOutputs = @{}
+    $NamedOutputs["new_source_group"] = $new_source_group.Name
+    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+}
+
+<#
+    .SYNOPSIS
+    Synchronize a replication group. Must be run on a "Target" Replication Group.
+
+    .PARAMETER ReplicationGroupID
+    Replication group ID
+
+    .PARAMETER PointInTimeReplicaName
+    Optional. Point-in-time replica name. If not provided, the latest point-in-time replica will be used.
+
+    .EXAMPLE
+    Sync-ReplicationGroup -ReplicationGroupID "myRepGroupID"
+
+    .INPUTS
+    Replication Group ID
+
+    .OUTPUTS
+    None.
+#>
+function Sync-ReplicationGroup {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    Param(
+        [Parameter(
+                Mandatory = $true,
+                HelpMessage = 'Replication group ID')]
+        [ValidateNotNull()]
+        [String]$ReplicationGroupID,
+
+        [Parameter(
+                Mandatory = $true,
+                HelpMessage = 'Point-in-time replica name')]
+        [ValidateNotNull()]
+        [String]$PointInTimeReplicaName
+    )
+
+    $repGroup = Get-SpbmReplicationGroup -ID $ReplicationGroupID
+    if (-not $repGroup) {
+        throw "Could not find replication group '$ReplicationGroupID'."
+    }
+    elseif ($repGroup.State -ne "Target") {
+        throw "Replication group '$ReplicationGroupID' need to be a replication group in 'Target' state."
+    }
+
+    Write-Host "Starting replication sync for replication group $ReplicationGroupID..."
+    Sync-SpbmReplicationGroup -ReplicationGroup $repGroup -PointInTimeReplicaName $PointInTimeReplicaName
+}


### PR DESCRIPTION


This PR closes #

The changes in this PR are as follows:
Added new cmdlets for failover management.
New cmdlets added are
* Start-ReplicationFailover
* Stop-ReplicationTestFailover
* Start-ReplicationReverse
* Sync-ReplicationGroup

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
              Tested against on-premise instances.
* [X] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

