### PR TITLE
Update build pipeline to use new task versions

### DIFF
--- a/.ci/templates/common-officialBuild-compliance-stages.yml
+++ b/.ci/templates/common-officialBuild-compliance-stages.yml
@@ -15,13 +15,13 @@ stages:
       inputs:
         sourceScanPath: '$(Build.SourcesDirectory)'
         snapshotForceEnabled: true
-    - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
       displayName: 'Run CredScan'
       inputs:
-        toolMajorVersion: V2
+        toolVersion: Latest
         debugMode: false
       continueOnError: false
-    - task: PoliCheck@1
+    - task: PoliCheck@2
       displayName: 'Run PoliCheck'
       inputs:
         targetType: F
@@ -30,10 +30,10 @@ stages:
         optionsPE: '1|2|3|4'
         optionsHMENABLE: 0
       continueOnError: false
-    - task: PublishSecurityAnalysisLogs@2
+    - task: PublishSecurityAnalysisLogs@3
       displayName: 'Publish Security Analysis Logs to Build Artifacts'
       continueOnError: false
-    - task: SdtReport@1
+    - task: SdtReport@2
       inputs:
         AllTools: false
         APIScan: false


### PR DESCRIPTION
The changes in this PR are as follows:

* Updates the build tasks to a more recent version to suppress task deprecation warning messages.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

