### PR TITLE
Mark selected RunCommands with AutomationOnly attribute

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -913,7 +913,7 @@ function Disconnect-NVMeTCPTarget {
 
 function Remove-VmfsDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
    
     Param
     (

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -24,7 +24,7 @@ using module Microsoft.AVS.Management
 #>
 function New-VvolDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory = $true,
@@ -93,7 +93,7 @@ function New-VvolDatastore {
 #>
 function Remove-VvolDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory = $true,
@@ -158,7 +158,7 @@ function Remove-VvolDatastore {
 #>
 function Update-VMHostCertificate {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param ()
 
     $service_instance = Get-View ServiceInstance
@@ -190,7 +190,7 @@ function Update-VMHostCertificate {
 #>
 function New-VvolVasaProvider {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory = $true,
@@ -242,7 +242,7 @@ function New-VvolVasaProvider {
 #>
 function Remove-VvolVasaProvider {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
             Mandatory = $true,
@@ -299,7 +299,7 @@ function Remove-VvolVasaProvider {
 #>
 function New-VvolStoragePolicy {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param(
         [Parameter(
             Mandatory = $true,
@@ -362,7 +362,7 @@ function New-VvolStoragePolicy {
 #>
 function Remove-VvolStoragePolicy {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param(
         [Parameter(
             Mandatory = $true,
@@ -404,7 +404,7 @@ function Remove-VvolStoragePolicy {
 #>
 function Start-ReplicationFailover {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param(
         [Parameter(
                 Mandatory = $true,
@@ -487,7 +487,7 @@ function Start-ReplicationFailover {
 #>
 function Stop-ReplicationTestFailover {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param(
         [Parameter(
                 Mandatory = $true,
@@ -526,7 +526,7 @@ function Stop-ReplicationTestFailover {
 #>
 function Start-ReplicationReverse {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param(
         [Parameter(
                 Mandatory = $true,
@@ -572,7 +572,7 @@ function Start-ReplicationReverse {
 #>
 function Sync-ReplicationGroup {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param(
         [Parameter(
                 Mandatory = $true,


### PR DESCRIPTION
Add automation attributes to selected cmdlets to prevent showing in Azure GUI


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
      Tested on on-premise deployment
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

