### PR TITLE
Fix invalid check for Datastore name

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -423,7 +423,7 @@ function Restore-VmfsVolume {
         throw "Cluster $ClusterName does not exist."
     }
 
-    if (-not $DatastoreName) {
+    if ($DatastoreName) {
         $Datastore = Get-Datastore -Name $DatastoreName -ErrorAction Ignore
         if ($Datastore) {
             throw "Datastore '$Datastore' already exists."


### PR DESCRIPTION
Fixed a buf where we are checking for DatastoreName is null where we should check that it is not null instead 
I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
        Tested using on-premise deployment
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.


