### PR TITLE
Set AutomationOnly attribute for VMFS functions

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1404,7 +1404,7 @@ function Get-VmKernelAdapters {
 
 function Set-NVMeTCP {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
 
     Param
     (
@@ -1487,7 +1487,7 @@ function Set-NVMeTCP {
 
 function New-NVMeTCPAdapter {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
 
     Param
     (


### PR DESCRIPTION
The changes in this PR are as follows:

* Set AutomationOnly attribute for NVMeTCP functions.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

