### PR TITLE
Fix bug in returning VM information in Start_ReplicationFailover

### DIFF
--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -464,6 +464,7 @@ function Start-ReplicationFailover {
     $i = 0
     foreach ($VMFile in $replicatedVMFiles) {
         $NamedOutputs["vm_$i"] = $VMFile
+        $i = $i + 1
     }
 
     Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global


### PR DESCRIPTION
Fix bug in returning VM information in Start_ReplicationFailover
Adding an accidentally missing loop increment variable wich might result in overwriting return data

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
        On-premise testing
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

