### PR TITLE
Capture and Reuse VC Connection Session

### DIFF
--- a/Microsoft.AVS.Management/HcxUtils.ps1
+++ b/Microsoft.AVS.Management/HcxUtils.ps1
@@ -109,13 +109,25 @@ function Get-HcxMetaData {
 <#
     .Synopsis
     Get and return HCX Virtual machine
+
+    .Parameter Connection
+    Specifies which connection to use
+
     .Example
-    Get-HcxManagerVM
+    Get-HcxManagerVM -Connection $VcConnection
 #>
 function Get-HcxManagerVM {
+    Param (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the connection to use')]
+        [ValidateNotNullOrEmpty()]
+        $Connection
+    )
+
     Write-Host "Identifying HCX VM"
     $HcxVm = $null
-    $VmsList = Get-VM
+    $VmsList = Get-VM -Server $Connection
 
     foreach ($Vm in $VmsList) {
         if($Vm.Name.Contains("HCX-MGR")) {


### PR DESCRIPTION
### Problem

The scriptUser session was being used to retrieve HCX vm information and it's role does have the priviledge to turn on/off the VM.

### Solution

Using the tempUser session with VC to retrieve the HCX vm information and pass that to subsequent function calls. 
I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

