### PR TITLE
Remove `using module` to import Microsoft.AVS.Management classes

### DIFF
--- a/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psd1
+++ b/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psd1
@@ -29,7 +29,7 @@
     Description = 'Azure VMware Solutions NFS Package.'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '7.2'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.3.99" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "6.0.112" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psm1
+++ b/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psm1
@@ -1,4 +1,3 @@
-using module Microsoft.AVS.Management
 <#
     .SYNOPSIS
      This function mounts the NFS datastore on all hosts in the cluster.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -29,7 +29,7 @@
     Description = 'Azure VMware Solutions VMFS Package'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '7.2'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.3.99" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "6.0.112" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1,5 +1,3 @@
-using module Microsoft.AVS.Management
-
 <#
     .SYNOPSIS
      This function updates all hosts in the specified cluster to have the following iSCSI configurations:

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
@@ -29,7 +29,7 @@
     Description       = 'Azure VMware Solutions VVOLS Package.'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion = '7.2'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.3.99" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "6.0.112" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psm1
@@ -1,5 +1,3 @@
-using module Microsoft.AVS.Management
-
 <#
     .SYNOPSIS
      Creates a new vVol datastore and mounts to a VMware cluster.


### PR DESCRIPTION
This PR resolves the new issue where the agent fails to install modules depending on `Microsoft.AVS.Management` if the dependency is older than the latest already installed on the agent. 

- [x] Testing: tested locally, will need a preview version to be sure.
