### PR TITLE
Update functions to export for VMFS preview package

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -76,16 +76,12 @@
         "Sync-VMHostStorage",
         "Sync-ClusterVMHostStorage",
         "Remove-VMHostStaticIScsiTargets",
-        "Connect-NVMeTCPTarget",
-        "Disconnect-NVMeTCPTarget",
         "Remove-VmfsDatastore",
         "Mount-VmfsDatastore",
         "Get-VmfsDatastore",
         "Get-VmfsHosts",
         "Get-StorageAdapters",
-        "Get-VmKernelAdapters",
-        "Set-NVMeTCP",
-        "New-NVMeTCPAdapter"
+        "Get-VmKernelAdapters"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "6.0.112" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "5.3.99" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -531,7 +531,7 @@ function Sync-VMHostStorage {
 #>
 function Sync-ClusterVMHostStorage {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
     Param (
         [Parameter(
                 Mandatory=$true,

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1,4 +1,4 @@
-using module Microsoft.AVS.Management
+using module @{ ModuleName = 'Microsoft.AVS.Management'; RequiredVersion = '5.3.99' }
 
 <#
     .SYNOPSIS

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1,3 +1,5 @@
+using module Microsoft.AVS.Management
+
 <#
     .SYNOPSIS
      This function updates all hosts in the specified cluster to have the following iSCSI configurations:


### PR DESCRIPTION
The changes in this PR are as follows:

* Remove `AutomationOnly` attribute for cmdlet `Sync-ClusterVMHostStorage`.
* Update `FunctionsToExport` for VMFS preview package version.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

