### PR TITLE
Grant ReadOnly to CloudAdmins on secure folder

### DIFF
--- a/Microsoft.AVS.Management/Classes.ps1
+++ b/Microsoft.AVS.Management/Classes.ps1
@@ -36,11 +36,11 @@ class AVSSecureFolder {
     #>
     hidden static ApplyPermissions($objects) {
         $admin = Get-VIRole -Name "Admin" -ErrorAction Stop
-        $noAccess = Get-VIRole -Name "NoAccess" -ErrorAction Stop
+        $readOnly = Get-VIRole -Name "ReadOnly" -ErrorAction Stop
         $scripting = Get-VIAccount -Id "scripting" -Domain "vsphere.local" -ErrorAction Stop
         $group = Get-VIAccount -Group -Id "CloudAdmins" -Domain "vsphere.local" -ErrorAction Stop
         $objects | New-VIPermission -Principal $scripting -Role $admin -Propagate $true
-        $objects | New-VIPermission -Principal $group -Role $noAccess -Propagate $true
+        $objects | New-VIPermission -Principal $group -Role $readOnly -Propagate $true
     }
 
     <#

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ If necessary, use the installation script to create a separate vCenter user and 
 ### Protecting service credentials
 If deploying an appliance in customer infrastruture that needs service credentials with privileges above `cloudadmins` role the vendor must ensure that the credentials are never exposed - not in-flight, nor at rest.
 - The appliance user must not be able to gain root access or direct access to the storage or file system where credentials are stored.
-- The appliance must be deployed in a folder with NoAccess permission to `CloudAdmins` SSO group. See `[AVSSecureFolder]::Root()` and `[AVSSecureFolder]::GetOrCreate()`.
+- The appliance must be deployed in a folder with ReadOnly permission to `CloudAdmins` SSO group. See `[AVSSecureFolder]::Root()` and `[AVSSecureFolder]::GetOrCreate()`.
 - The objects deployed into the secure folder must subseqently be re-secured with `[AVSSecureFolder]::Secure()` method.
 - The credentials must be passed as OVA properties to the appliance, including the rotation scenario.
 - The credentials must never be logged, no diagnostic bundle may include the credentials.


### PR DESCRIPTION
This PR changes secure folder permissions to grant CloudAdmins ReadOnly access to align with MGMT Pool permissions changes.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

