### PR TITLE
Change max VMFS size to 64 TB instead of 62 TB

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -158,8 +158,8 @@ function New-VmfsDatastore {
         throw "Invalid Size $Size provided."
     }
 
-    if (($SizeInBytes -lt 1073741824) -or ($SizeInBytes -gt 68169720922112)) {
-        throw "Invalid Size $SizeInBytes provided. Size should be between 1 GB and 62 TB."
+    if (($SizeInBytes -lt 1GB) -or ($SizeInBytes -gt 64TB)) {
+        throw "Invalid Size $SizeInBytes provided. Size should be between 1 GB and 64 TB."
     }
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Change max VMFS size to 64 TB instead of 62 TB

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [X ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
Tested using on-premise deployment
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

