### PR TITLE
Update-IdentitySourceCertificates With No SAS

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -263,7 +263,7 @@ function Get-CertificateFromServerToLocalFile {
     )
 
     $DestinationFileArray = @()
-    $exportFolder = "./"
+    $exportFolder = $pwd.Path + "/"
     foreach ($computerUrl in $remoteComputers) {
         if (![uri]::IsWellFormedUriString($computerUrl, 'Absolute')) { 
             throw "Incorrect Url format entered from: $computerUrl" 


### PR DESCRIPTION
The changes in this PR are as follows:

* Parameter `SSLCertificatesSasUrl` in command `Update-IdentitySourceCertificates` is no longer mandatory. If `SSLCertificatesSasUrl` is not provided, it automatically downloads certificates from domain controllers to update. 

Test:
<img width="769" alt="image" src="https://github.com/Azure/Microsoft.AVS.Management/assets/60164697/33b59d66-aa70-44a1-9247-b1e586bffcc2">
![image](https://github.com/Azure/Microsoft.AVS.Management/assets/60164697/42cd8216-2a92-47a8-9691-10e09eacde41)


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

