### PR TITLE
Resize flash and non-flash volume

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -329,8 +329,8 @@ function Resize-VmfsVolume {
         $DeviceNaaId
     )
 
-    if ($DeviceNaaId -notlike 'naa.624a9370*') {
-        throw "Invalid Device NAA ID $DeviceNaaId provided."
+    if (-not $DeviceNaaId) {
+        throw "Invalid Device ID $DeviceNaaId provided."
     }
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore


### PR DESCRIPTION
This PR enables resizing VMFS datastore on flash and non-flash devices, removing the hard check that blocks resizing datastore on flash devices. 

The changes in this PR are as follows:

* ... Remove a hard-check that blocks resizing non naa.* devices.
* ... Resize flash and non-flash devices. 
* ...

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

