### PR TITLE
Remove NVMeTCP exported functions

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -81,11 +81,7 @@
         "Get-VmfsDatastore",
         "Get-VmfsHosts",
         "Get-StorageAdapters",
-        "Get-VmKernelAdapters",
-        "Connect-NVMeTCPTarget",
-        "Disconnect-NVMeTCPTarget",
-        "Set-NVMeTCP",
-        "New-NVMeTCPAdapter"
+        "Get-VmKernelAdapters"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
The changes in this PR are as follows:

* Removes NVMeTCP exported functions from the FunctionsToExport list.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

