### PR TITLE
Implement Enhanced Resource Pool Reservation Management for Scaled VMs

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1582,11 +1582,8 @@ function Set-HcxScaledCpuAndMemorySetting {
         $HcxServer = 'hcx'
         $HcxPreferredVersion = '4.3.2'
         $DiskUtilizationTreshold = 90
-        $HcxScaledtNumCpu = 8
+        $HcxScaledNumCpu = 8
         $HcxScaledMemoryGb = 24
-        $ResourcePoolName = 'MGMT-ResourcePool'
-        $ResourcePoolCpuReservationIncrease = 8000
-        $ResourcePoolMemoryReservationIncrease = 12000
 
         $HcxVm = Get-HcxManagerVM -Connection $VcenterConnection
         if (-not $HcxVm) {
@@ -1595,8 +1592,8 @@ function Set-HcxScaledCpuAndMemorySetting {
         if ($HcxVm.PowerState -ne "PoweredOn") {
             throw "$($HcxVm.Name) must be powered on. Current powerstate is $($HcxVm.PowerState)."
         }
-        if (($HcxVm.NumCpu -eq $HcxScaledtNumCpu) -and
-        ($HcxVm.MemoryGb -eq $HcxScaledMemoryGb)) {
+        if (($HcxVm.NumCpu -ge $HcxScaledNumCpu) -and
+        ($HcxVm.MemoryGb -ge $HcxScaledMemoryGb)) {
             throw "HCX VM: $($HcxVm.Name) is already scaled to $($HcxVm.NumCpu) CPUs and $($HcxVm.MemoryGb) Memory."
         }
 
@@ -1610,7 +1607,6 @@ function Set-HcxScaledCpuAndMemorySetting {
         if ($migratingVmsCount -gt 0) {
             throw "There are $migratingVmsCount active migrations. Resume operation at a later time"
         }
-
         Write-Host "$migratingVmsCount active migrations found."
 
         $XHmAuthorization = Get-AuthorizationToken -Credential $HcxAdminCredential -HcxServer $HcxServer
@@ -1619,12 +1615,10 @@ function Set-HcxScaledCpuAndMemorySetting {
         if ($HcxCurrentVersion -lt $HcxPreferredVersion) {
             throw "Current HCX version: $HcxCurrentVersion is less than the prefered version: $HcxPreferredVersion"
         }
-
         Write-Host "Current HCX Version: $HcxCurrentVersion"
 
         Write-Host "Retrieving Appliances"
         $Appliances = Get-HCXAppliance
-
         if ($Appliances.Count -gt 0) {
             $VersionPerAppliance = @{
                 Interconnect   = $HcxPreferredVersion;
@@ -1646,6 +1640,27 @@ function Set-HcxScaledCpuAndMemorySetting {
         $MonitoredDisks = @("/common")
         Invoke-DiskUtilizationThresholdCheck -DiskUtilizationTreshold $DiskUtilizationTreshold -MonitoredDisks $MonitoredDisks -Disks $HcxVmGuest.Disks
 
+        $ResourcePool = Get-ResourcePoolByName -Server $VcenterConnection
+        $AvailableMemoryGB = $ResourcePool.extensiondata.Runtime.memory.unreservedforVM / 1024 / 1024 / 1024
+        $AvailableCpuMHz = $ResourcePool.extensiondata.Runtime.cpu.unreservedforVM
+        $CpuModifier = $HcxScaledNumCpu - $HcxVm.NumCpu
+        $MemoryModifier = $HcxScaledMemoryGb - $HcxVm.MemoryGB
+        if ($AvailableMemoryGB -lt $HcxScaledMemoryGb) {
+            throw "Not enough memory available to support new HCX size.  Memory available is $AvailableMemoryGB GB, memory required is $MemoryModifier GB."
+        }
+        if ($AvailableCpuMHz -lt $HcxScaledNumCpu) {
+            throw` "Not enough CPU available to support new HCX size.  CPU available is $AvailableCpuMHz MHz, CPU required is $CpuModifier MHz."
+        }
+
+        Write-Host "Configuring memory and cpu settings - Memory: $MemoryModifier CPU: $CpuModifier"
+        $params = @{
+            Server = $VcenterConnection
+            ResourcePool = $ResourcePool
+            MemReservationGB = $MemoryModifier
+            CpuReservationMhz = $CpuModifier
+        }
+        Set-ResourcePoolReservation @params
+
         $timeout = 60
         $startTime = Get-Date
 
@@ -1662,16 +1677,7 @@ function Set-HcxScaledCpuAndMemorySetting {
         }
         Write-Host "Guest OS is shut down"
 
-        Write-Host "Configuring memory and cpu settings"
-        $params = @{
-            Server = $VcenterConnection
-            ResourcePoolName = $ResourcePoolName
-            MemReservationMBIncrease = $ResourcePoolMemoryReservationIncrease
-            CpuReservationMhzIncrease = $ResourcePoolCpuReservationIncrease
-        }
-        Set-ResourcePoolReservation @params
-
-        Set-VM -VM $HcxVm -MemoryGB $HcxScaledMemoryGb -NumCpu $HcxScaledtNumCpu -Confirm:$false -Server $VcenterConnection | Out-Null
+        Set-VM -VM $HcxVm -MemoryGB $HcxScaledMemoryGb -NumCpu $HcxScaledNumCpu -Confirm:$false -Server $VcenterConnection | Out-Null
 
         Write-Host "Starting $($HcxVm.Name)..."
         Start-VM -VM $HcxVm -Confirm:$false -Server $VcenterConnection | Out-Null
@@ -1680,11 +1686,11 @@ function Set-HcxScaledCpuAndMemorySetting {
         Write-Host "Waiting for successful connection to HCX appliance..."
         $hcxConnection = Test-HcxConnection -Server $HcxServer -Count 12 -Port $Port -Credential $HcxAdminCredential -HcxVm $HcxVm
 
-        $HcxVm = Get-VM -Name $HcxVm.Name -Server $VcenterConnection
-        Write-Host "HCX-Scale: $($HcxVm.Name)'s CPU: $($HcxVm.NumCpu) and Memory: $($HcxVm.MemoryGb) Gb Settings"
+        $UpdatedHcxVm = Get-VM -Name $HcxVm.Name -Server $VcenterConnection
+        Write-Host "HCX-Scale: $($UpdatedHcxVm.Name)'s Original CPU: $($HcxVm.NumCpu) and Memory: $($HcxVm.MemoryGb) Gb Settings. New CPU: $($UpdatedHcxVm.NumCpu) and Memory: $($UpdatedHcxVm.MemoryGb) Gb Settings"
 
-        if ($HcxVm.NumCpu -ne $HcxScaledtNumCpu -or $HcxVm.MemoryGb -ne $HcxScaledMemoryGb) {
-            throw "Failed to set HCX VM: $($HcxVm.Name) to the desired configuration of $($HcxScaledtNumCpu) CPUs and $($HcxScaledMemoryGb) GB Memory."
+        if ($UpdatedHcxVm.NumCpu -ne $HcxScaledNumCpu -or $UpdatedHcxVm.MemoryGb -ne $HcxScaledMemoryGb) {
+            throw "Failed to set HCX VM: $($UpdatedHcxVm.Name) to the desired configuration of $($HcxScaledNumCpu) CPUs and $($HcxScaledMemoryGb) GB Memory."
         }
 
         Write-Host "Configuration complete"

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1682,6 +1682,11 @@ function Set-HcxScaledCpuAndMemorySetting {
 
         $HcxVm = Get-VM -Name $HcxVm.Name -Server $VcenterConnection
         Write-Host "$($hcxVm.Name)'s CPU: $($HcxVm.NumCpu) and Memory: $($HcxVm.MemoryGb) Gb Settings"
+
+        if ($HcxVm.NumCpu -ne $HcxScaledtNumCpu -or $HcxVm.MemoryGb -ne $HcxScaledMemoryGb) {
+            throw "Failed to set HCX VM: $($HcxVm.Name) to the desired configuration of $($HcxScaledtNumCpu) CPUs and $($HcxScaledMemoryGb) GB Memory."
+        }
+
         Write-Host "Configuration complete"
     }
     catch {

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1681,7 +1681,7 @@ function Set-HcxScaledCpuAndMemorySetting {
         $hcxConnection = Test-HcxConnection -Server $HcxServer -Count 12 -Port $Port -Credential $HcxAdminCredential -HcxVm $HcxVm
 
         $HcxVm = Get-VM -Name $HcxVm.Name -Server $VcenterConnection
-        Write-Host "$($hcxVm.Name)'s CPU: $($HcxVm.NumCpu) and Memory: $($HcxVm.MemoryGb) Gb Settings"
+        Write-Host "HCX-Scale: $($hcxVm.Name)'s CPU: $($HcxVm.NumCpu) and Memory: $($HcxVm.MemoryGb) Gb Settings"
 
         if ($HcxVm.NumCpu -ne $HcxScaledtNumCpu -or $HcxVm.MemoryGb -ne $HcxScaledMemoryGb) {
             throw "Failed to set HCX VM: $($HcxVm.Name) to the desired configuration of $($HcxScaledtNumCpu) CPUs and $($HcxScaledMemoryGb) GB Memory."

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1673,15 +1673,15 @@ function Set-HcxScaledCpuAndMemorySetting {
 
         Set-VM -VM $HcxVm -MemoryGB $HcxScaledMemoryGb -NumCpu $HcxScaledtNumCpu -Confirm:$false -Server $VcenterConnection | Out-Null
 
-        Write-Host "Starting $($hcxVm.Name)..."
+        Write-Host "Starting $($HcxVm.Name)..."
         Start-VM -VM $HcxVm -Confirm:$false -Server $VcenterConnection | Out-Null
-        Write-Host "$($hcxVm.Name)'s powerstate=$($hcxVm.PowerState)"
+        Write-Host "$($HcxVm.Name)'s powerstate=$($HcxVm.PowerState)"
 
         Write-Host "Waiting for successful connection to HCX appliance..."
         $hcxConnection = Test-HcxConnection -Server $HcxServer -Count 12 -Port $Port -Credential $HcxAdminCredential -HcxVm $HcxVm
 
         $HcxVm = Get-VM -Name $HcxVm.Name -Server $VcenterConnection
-        Write-Host "HCX-Scale: $($hcxVm.Name)'s CPU: $($HcxVm.NumCpu) and Memory: $($HcxVm.MemoryGb) Gb Settings"
+        Write-Host "HCX-Scale: $($HcxVm.Name)'s CPU: $($HcxVm.NumCpu) and Memory: $($HcxVm.MemoryGb) Gb Settings"
 
         if ($HcxVm.NumCpu -ne $HcxScaledtNumCpu -or $HcxVm.MemoryGb -ne $HcxScaledMemoryGb) {
             throw "Failed to set HCX VM: $($HcxVm.Name) to the desired configuration of $($HcxScaledtNumCpu) CPUs and $($HcxScaledMemoryGb) GB Memory."

--- a/Microsoft.AVS.Management/ResourcePoolUtils.ps1
+++ b/Microsoft.AVS.Management/ResourcePoolUtils.ps1
@@ -106,8 +106,8 @@ function Set-ResourcePoolReservation {
     $newMemReservation = $currentMemReservation + $MemReservationMBIncrease
     $newCpuReservation = $currentCpuReservation + $CpuReservationMhzIncrease
 
-    Write-Host "Current CPU Reservation: $currentCpuReservation MHz, New CPU Reservation: $newCpuReservation MHz; Delta $CpuReservationMhzIncrease MHz"
-    Write-Host "Current Memory Reservation: $currentMemReservation MB, New Memory Reservation: $newMemReservation MB; Delta $MemReservationMBIncrease MB"
+    Write-Host "Resource-Pool-Scale: Current CPU Reservation: $currentCpuReservation MHz, New CPU Reservation: $newCpuReservation MHz; Delta $CpuReservationMhzIncrease MHz"
+    Write-Host "Resource-Pool-Scale: Current Memory Reservation: $currentMemReservation MB, New Memory Reservation: $newMemReservation MB; Delta $MemReservationMBIncrease MB"
 
     Set-ResourcePool -ResourcePool $resourcePool -CpuReservationMhz $newCpuReservation -MemReservationMB $newMemReservation -Server $Server -ErrorAction Stop | out-null
 

--- a/Microsoft.AVS.Management/ResourcePoolUtils.ps1
+++ b/Microsoft.AVS.Management/ResourcePoolUtils.ps1
@@ -105,6 +105,11 @@ function Set-ResourcePoolReservation {
     $CpuReservationMhzTotal = $NewCpuReservation * 1000
     $CpuSharesTotal = $NewCpuReservation * 2000
 
+    $Defaults = Get-DefaultResourcePoolConfig
+    $NewMemReservation = [Math]::Max($NewMemReservation, $Defaults.mem_reservation)
+    $CpuReservationMhzTotal = [Math]::Max($CpuReservationMhzTotal, $Defaults.cpu_reservation)
+    $CpuSharesTotal = [Math]::Max($CpuSharesTotal, $Defaults.cpu_allocation_shares)
+
     Write-Host "ResourcePool-Scale: Current CPU Reservation: $($ResourcePool.CpuReservationMhz) MHz, New CPU Reservation: $CpuReservationMhzTotal MHz; Delta $($CpuReservationMhzTotal - $ResourcePool.CpuReservationMhz) MHz"
     Write-Host "ResourcePool-Scale: Current CPU Shares: $($ResourcePool.NumCpuShares), New CPU Shared: $CpuSharesTotal; Delta Shares $($CpuSharesTotal - $ResourcePool.NumCpuShares)"
     Write-Host "ResourcePool-Scale: Current Memory Reservation: $($ResourcePool.MemReservationGB) GB, New Memory Reservation: $NewMemReservation GB; Delta $($NewMemReservation - $ResourcePool.MemReservationGB) GB"
@@ -116,4 +121,39 @@ function Set-ResourcePoolReservation {
         $UpdatedResourcePool.MemReservationGB -ne $NewMemReservation) {
         throw "Failed to update reservations correctly for $($UpdatedResourcePool.Name)"
     }
+}
+
+<#
+    .SYNOPSIS
+    Retrieves the default configuration settings for a resource pool.
+
+    .DESCRIPTION
+    The Get-DefaultResourcePoolConfig function returns a hashtable containing default configuration settings for resource pools.
+
+    .PARAMETER None
+    This function does not take any parameters.
+
+    .OUTPUTS
+    System.Collections.Hashtable
+    Returns a hashtable with the default configuration settings for resource pools, including:
+    - cpu_reservation: The default CPU reservation in MHz.
+    - cpu_shares: The default CPU shares level (custom).
+    - cpu_allocation_shares: The default CPU allocation shares.
+    - mem_reservation: The default memory reservation in GB.
+    - mem_shares: The default memory shares level (high).
+
+    .EXAMPLE
+    $defaultConfig = Get-DefaultResourcePoolConfig
+    This example retrieves the default resource pool configuration settings and stores them in the `$defaultConfig` variable.
+#>
+function Get-DefaultResourcePoolConfig {
+    $ResourcePoolDefaults = @{
+        cpu_reservation = 46000
+        cpu_shares = 'custom'
+        cpu_allocation_shares = 92000
+        mem_reservation = 176
+        mem_shares = 'high'
+    }
+
+    return $ResourcePoolDefaults
 }

--- a/Microsoft.AVS.Management/ResourcePoolUtils.ps1
+++ b/Microsoft.AVS.Management/ResourcePoolUtils.ps1
@@ -106,10 +106,10 @@ function Set-ResourcePoolReservation {
     $newMemReservation = $currentMemReservation + $MemReservationMBIncrease
     $newCpuReservation = $currentCpuReservation + $CpuReservationMhzIncrease
 
-    Write-Host "Current CPU Reservation: $currentCpuReservation MHz, New CPU Reservation: $newCpuReservation MHz"
-    Write-Host "Current Memory Reservation: $currentMemReservation MB, New Memory Reservation: $newMemReservation MB"
+    Write-Host "Current CPU Reservation: $currentCpuReservation MHz, New CPU Reservation: $newCpuReservation MHz; Delta $CpuReservationMhzIncrease MHz"
+    Write-Host "Current Memory Reservation: $currentMemReservation MB, New Memory Reservation: $newMemReservation MB; Delta $MemReservationMBIncrease MB"
 
-    Set-ResourcePool -ResourcePool $resourcePool -CpuReservationMhz $newCpuReservation -MemReservationMB $newMemReservation -Server $Server | out-null
+    Set-ResourcePool -ResourcePool $resourcePool -CpuReservationMhz $newCpuReservation -MemReservationMB $newMemReservation -Server $Server -ErrorAction Stop | out-null
 
     $updatedResourcePool = Get-ResourcePoolByName -Server $Server -ResourcePoolName $ResourcePoolName
     if ($updatedResourcePool.CpuReservationMhz -ne $newCpuReservation -or

--- a/Microsoft.AVS.Management/ResourcePoolUtils.ps1
+++ b/Microsoft.AVS.Management/ResourcePoolUtils.ps1
@@ -23,7 +23,7 @@
     Specifies the server from which to retrieve the resource pool. This parameter is mandatory.
 
     .PARAMETER ResourcePoolName
-    Specifies the name of the resource pool to retrieve. This parameter  accepts a string value.
+    Specifies the name of the resource pool to retrieve. This parameter accepts a string value.
 
     .EXAMPLE
     Get-ResourcePoolByName -Server "ServerName" -ResourcePoolName "MyResourcePool"
@@ -45,11 +45,9 @@ function Get-ResourcePoolByName {
 
     $ResourcePool = Get-ResourcePool -Name $ResourcePoolName -Server $Server -ErrorAction Stop
 
-    if ($null -eq $ResourcePool) {
-        throw "Resource pool '$ResourcePoolName' not found on server '$Server'."
-    } else {
-            return $ResourcePool
-    }
+    if ($null -eq $ResourcePool) { throw "Resource pool '$ResourcePoolName' not found on server '$Server'." }
+
+    return $ResourcePool
 }
 
 <#
@@ -65,14 +63,17 @@ function Get-ResourcePoolByName {
     .PARAMETER ResourcePool
     Specifies the resource pool whose reservations are to be updated. This parameter is mandatory.
 
-    .PARAMETER MemReservationGB
+    .PARAMETER MemoryReservation
     Specifies the amount by which to increase the memory reservation, in gigabytes (GB). This parameter is mandatory.
 
-    .PARAMETER CpuReservationMhz
+    .PARAMETER CpuReservation
     Specifies the amount by which to increase the CPU reservation, in megahertz (MHz). This parameter is mandatory.
 
+    .PARAMETER SharesReservation
+    Specifies the amount by which to increase the CPU shares reservation. This parameter is mandatory.
+
     .EXAMPLE
-    Set-ResourcePoolReservation -Server 'Server1' -ResourcePool 'ResourcePoolA' MemReservationGB 5 CpuReservationMhz 10
+    Set-ResourcePoolReservation -Server 'Server1' -ResourcePool 'ResourcePoolA' -MemoryReservation 5 -CpuReservation 10 -SharesReservation 0
     This command increases the memory reservation of 'ResourcePoolA' on 'Server1' by 5 GB and the CPU reservation by 10 MHz.
 #>
 function Set-ResourcePoolReservation {
@@ -91,34 +92,39 @@ function Set-ResourcePoolReservation {
         [Parameter(
             Mandatory = $true,
             HelpMessage = 'Specify the memory reservation in GB')]
-        [int]$MemReservationGB,
+        [int]$MemoryReservation,
 
         [Parameter(
             Mandatory = $true,
-            HelpMessage = 'Specify the CPU reservation in MHz')]
-        [int]$CpuReservationMhz
+            HelpMessage = 'Specify the CPU reservation in Mhz')]
+        [int]$CpuReservation,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the CPU shares reservation')]
+        [int]$SharesReservation
     )
 
-    $ResourcePoolVms = $ResourcePool | Get-VM
-    [int]$NewMemReservation = ($ResourcePoolVms.MemoryGb | Measure-Object -Sum).Sum + $MemReservationGB
-    [int]$NewCpuReservation = ($ResourcePoolVms.NumCpu | Measure-Object -Sum).Sum + $CpuReservationMhz
-    $CpuReservationMhzTotal = $NewCpuReservation * 1000
-    $CpuSharesTotal = $NewCpuReservation * 2000
-
     $Defaults = Get-DefaultResourcePoolConfig
-    $NewMemReservation = [Math]::Max($NewMemReservation, $Defaults.mem_reservation)
-    $CpuReservationMhzTotal = [Math]::Max($CpuReservationMhzTotal, $Defaults.cpu_reservation)
-    $CpuSharesTotal = [Math]::Max($CpuSharesTotal, $Defaults.cpu_allocation_shares)
 
-    Write-Host "ResourcePool-Scale: Current CPU Reservation: $($ResourcePool.CpuReservationMhz) MHz, New CPU Reservation: $CpuReservationMhzTotal MHz; Delta $($CpuReservationMhzTotal - $ResourcePool.CpuReservationMhz) MHz"
-    Write-Host "ResourcePool-Scale: Current CPU Shares: $($ResourcePool.NumCpuShares), New CPU Shared: $CpuSharesTotal; Delta Shares $($CpuSharesTotal - $ResourcePool.NumCpuShares)"
-    Write-Host "ResourcePool-Scale: Current Memory Reservation: $($ResourcePool.MemReservationGB) GB, New Memory Reservation: $NewMemReservation GB; Delta $($NewMemReservation - $ResourcePool.MemReservationGB) GB"
+    $NewMemReservation = $ResourcePool.MemReservationGB + $MemoryReservation
+    $NewCpuReservation = $ResourcePool.CpuReservationMHz + $CpuReservation
+    $NewSharesReservation = $ResourcePool.NumCpuShares + $SharesReservation
 
-    Set-ResourcePool -ResourcePool $ResourcePool -CpuReservationMhz $CpuReservationMhzTotal -CpuSharesLevel:Custom -NumCpuShares $CpuSharesTotal -MemReservationGB $NewMemReservation -MemSharesLevel:High -Server $Server -ErrorAction Stop | out-null
+    $NewMemReservation = AdjustReservationValue $NewMemReservation $MemoryReservation $Defaults.MemReservationGB 'Mem' $Defaults
+    $NewCpuReservation = AdjustReservationValue $NewCpuReservation $CpuReservation $Defaults.CpuReservationMhz 'Cpu' $Defaults
+    $NewSharesReservation = AdjustReservationValue $NewSharesReservation $SharesReservation $Defaults.NumCpuShares 'Shares' $Defaults
+
+    Write-Host "ResourcePool-Scale: Current Memory Reservation: $($ResourcePool.MemReservationGB) GB, New Memory Reservation: $NewMemReservation GB; Delta $($NewMemReservation - $ResourcePool.MemReservationGB) GB; Default Value Used: $($Defaults.DefaultsUsed.Mem)"
+    Write-Host "ResourcePool-Scale: Current CPU Reservation: $($ResourcePool.CpuReservationMhz) MHz, New CPU Reservation: $NewCpuReservation MHz; Delta $($NewCpuReservation - $ResourcePool.CpuReservationMhz) MHz; Default Value Used: $($Defaults.DefaultsUsed.Cpu)"
+    Write-Host "ResourcePool-Scale: Current CPU Shares: $($ResourcePool.NumCpuShares), New CPU Shares: $NewSharesReservation; Delta $($NewSharesReservation - $ResourcePool.NumCpuShares); Default Value Used: $($Defaults.DefaultsUsed.Shares)"
+
+    Set-ResourcePool -ResourcePool $ResourcePool -CpuReservationMhz $NewCpuReservation -CpuSharesLevel $Defaults.CpuSharesLevel -NumCpuShares $NewSharesReservation -MemReservationGB $NewMemReservation -MemSharesLevel $Defaults.MemSharesLevel -Server $Server -ErrorAction Stop | Out-Null
 
     $UpdatedResourcePool = Get-ResourcePoolByName -Server $Server
-    if ($UpdatedResourcePool.CpuReservationMhz -ne $CpuReservationMhzTotal -or
-        $UpdatedResourcePool.MemReservationGB -ne $NewMemReservation) {
+    if ($UpdatedResourcePool.CpuReservationMhz -ne $NewCpuReservation -or
+        $UpdatedResourcePool.MemReservationGB -ne $NewMemReservation -or
+        $UpdatedResourcePool.NumCpuShares -ne $NewSharesReservation) {
         throw "Failed to update reservations correctly for $($UpdatedResourcePool.Name)"
     }
 }
@@ -136,11 +142,11 @@ function Set-ResourcePoolReservation {
     .OUTPUTS
     System.Collections.Hashtable
     Returns a hashtable with the default configuration settings for resource pools, including:
-    - cpu_reservation: The default CPU reservation in MHz.
-    - cpu_shares: The default CPU shares level (custom).
-    - cpu_allocation_shares: The default CPU allocation shares.
-    - mem_reservation: The default memory reservation in GB.
-    - mem_shares: The default memory shares level (high).
+    - CpuReservationMhz: The default CPU reservation in MHz.
+    - CpuSharesLevel: The default CPU shares level (custom).
+    - NumCpuShares: The default CPU allocation shares.
+    - MemReservationGB: The default memory reservation in GB.
+    - MemSharesLevel: The default memory shares level (high).
 
     .EXAMPLE
     $defaultConfig = Get-DefaultResourcePoolConfig
@@ -148,12 +154,66 @@ function Set-ResourcePoolReservation {
 #>
 function Get-DefaultResourcePoolConfig {
     $ResourcePoolDefaults = @{
-        cpu_reservation = 46000
-        cpu_shares = 'custom'
-        cpu_allocation_shares = 92000
-        mem_reservation = 176
-        mem_shares = 'high'
+        CpuReservationMhz = 46000
+        CpuSharesLevel = 'Custom'
+        NumCpuShares = 92000
+        MemReservationGB = 176
+        MemSharesLevel = 'High'
+        DefaultsUsed = @{
+            Cpu = $false
+            Shares = $false
+            Mem = $false
+        }
     }
 
     return $ResourcePoolDefaults
+}
+
+<#
+    .SYNOPSIS
+    Adjusts a reservation value based on given parameters and default settings.
+
+    .DESCRIPTION
+    The AdjustReservationValue function updates a current reservation value by adding a specified amount to it if the current value is less than a default value. It also updates a hashtable to indicate that defaults were used for a particular type of reservation.
+
+    .PARAMETER CurrentValue
+    The current reservation value as an integer.
+
+    .PARAMETER ReservationToAdd
+    The amount to add to the current reservation value, as an integer.
+
+    .PARAMETER DefaultValue
+    The default reservation value. If the current value is less than this value, the function will adjust the current value based on the reservation to add.
+
+    .PARAMETER Type
+    The type of reservation being adjusted. This string parameter is used to update the hashtable indicating that defaults were applied.
+
+    .PARAMETER Defaults
+    A hashtable that tracks whether default values have been used for different types of reservations. The function updates this hashtable based on the operation performed.
+
+    .OUTPUTS
+    Int
+    Returns the adjusted current value after applying the reservation addition. If the current value was less than the default value, the return value reflects the sum of the default value and the reservation to add; otherwise, the original current value is returned unchanged.
+
+    .EXAMPLE
+    $defaults = @{DefaultsUsed = @{}}
+    $adjustedValue = AdjustReservationValue -CurrentValue 50 -ReservationToAdd 20 -DefaultValue 100 -Type "CPU" -Defaults $defaults
+    This example adjusts the reservation value for a CPU type. Since the current value (50) is less than the default value (100), the function will return 120 (100 + 20), and the hashtable will indicate that defaults were used for the CPU type.
+
+#>
+function AdjustReservationValue {
+    param (
+        [int]$CurrentValue,
+        [int]$ReservationToAdd,
+        [int]$DefaultValue,
+        [string]$Type,
+        [hashtable]$Defaults
+    )
+
+    if ($CurrentValue -lt $DefaultValue) {
+        $CurrentValue = $DefaultValue + $ReservationToAdd
+        $Defaults.DefaultsUsed.$Type = $true
+    }
+
+    return $CurrentValue
 }

--- a/Microsoft.AVS.Management/ResourcePoolUtils.ps1
+++ b/Microsoft.AVS.Management/ResourcePoolUtils.ps1
@@ -1,0 +1,119 @@
+<#PSScriptInfo
+    .VERSION 1.0
+
+    .GUID e1b10288-581e-4b3d-b315-f0bb54572d93
+
+    .AUTHOR Frantz Prinvil
+
+    .COMPANYNAME Microsoft
+
+    .COPYRIGHT (c) Microsoft. All rights reserved
+
+    .DESCRIPTION This script file contains utility functions for managing VMware vSphere resource pools through PowerShell commands
+#>
+
+<#
+    .SYNOPSIS
+    Retrieves a specified resource pool by name from a given server.
+
+    .DESCRIPTION
+    The Get-ResourcePoolByName function connects to a specified server and retrieves the resource pool with the provided name. If the resource pool is not found, it throws an error.
+
+    .PARAMETER Server
+    Specifies the server from which to retrieve the resource pool. This parameter is mandatory.
+
+    .PARAMETER ResourcePoolName
+    Specifies the name of the resource pool to retrieve. This parameter is mandatory and accepts a string value.
+
+    .EXAMPLE
+    Get-ResourcePoolByName -Server "ServerName" -ResourcePoolName "MyResourcePool"
+    This example retrieves a resource pool named "MyResourcePool" from the server "ServerName".
+#>
+function Get-ResourcePoolByName {
+    param (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the server to use')]
+        [ValidateNotNullOrEmpty()]
+        $Server,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the name of the resource pool')]
+        [string]$ResourcePoolName
+    )
+
+    $resourcePool = Get-ResourcePool -Name $ResourcePoolName -Server $Server -ErrorAction Stop
+
+    if ($null -eq $resourcePool) {
+        throw "Resource pool '$ResourcePoolName' not found on server '$Server'."
+    } else {
+            return $resourcePool
+    }
+}
+
+<#
+    .SYNOPSIS
+    Increases the CPU and memory reservations for a specified resource pool on a server.
+
+    .DESCRIPTION
+    The Set-ResourcePoolReservation function increases the CPU and memory reservations of a specified resource pool by a given amount. It retrieves the current resource pool's reservation settings, adds the specified increases, and updates the resource pool with the new values.
+
+    .PARAMETER Server
+    Specifies the server on which the resource pool is located. This parameter is mandatory.
+
+    .PARAMETER ResourcePoolName
+    Specifies the name of the resource pool whose reservations are to be updated. This parameter is mandatory.
+
+    .PARAMETER MemReservationMBIncrease
+    Specifies the amount by which to increase the memory reservation, in megabytes (MB). This parameter is mandatory.
+
+    .PARAMETER CpuReservationMhzIncrease
+    Specifies the amount by which to increase the CPU reservation, in megahertz (MHz). This parameter is mandatory.
+
+    .EXAMPLE
+    Set-ResourcePoolReservation -Server 'Server1' -ResourcePoolName 'ResourcePoolA' -MemReservationMBIncrease 500 -CpuReservationMhzIncrease 1000
+    This command increases the memory reservation of 'ResourcePoolA' on 'Server1' by 500 MB and the CPU reservation by 1000 MHz.
+#>
+function Set-ResourcePoolReservation {
+    param (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the server to use')]
+        [ValidateNotNullOrEmpty()]
+        $Server,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the name of the resource pool')]
+        [string]$ResourcePoolName,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the increase in memory reservation in MB')]
+        [int]$MemReservationMBIncrease,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Specify the increase in CPU reservation in MHz')]
+        [int]$CpuReservationMhzIncrease
+    )
+
+    $resourcePool = Get-ResourcePoolByName -Server $Server -ResourcePoolName $ResourcePoolName
+    $currentMemReservation = $resourcePool.MemReservationMB
+    $currentCpuReservation = $resourcePool.CpuReservationMhz
+
+    $newMemReservation = $currentMemReservation + $MemReservationMBIncrease
+    $newCpuReservation = $currentCpuReservation + $CpuReservationMhzIncrease
+
+    Write-Host "Current CPU Reservation: $currentCpuReservation MHz, New CPU Reservation: $newCpuReservation MHz"
+    Write-Host "Current Memory Reservation: $currentMemReservation MB, New Memory Reservation: $newMemReservation MB"
+
+    Set-ResourcePool -ResourcePool $resourcePool -CpuReservationMhz $newCpuReservation -MemReservationMB $newMemReservation -Server $Server | out-null
+
+    $updatedResourcePool = Get-ResourcePoolByName -Server $Server -ResourcePoolName $ResourcePoolName
+    if ($updatedResourcePool.CpuReservationMhz -ne $newCpuReservation -or
+        $updatedResourcePool.MemReservationMB -ne $newMemReservation) {
+        throw "Failed to update reservations correctly for '$ResourcePoolName'."
+    }
+}


### PR DESCRIPTION
**Background**
When enhancing a VM's capabilities, such as increasing CPU or memory, it's important to correspondingly adjust the resource pool reservations. This ensures that the VMs continue to operate efficiently after scaling. These changes provide a more efficient and less error-prone method for managing these adjustments.

The changes in this PR are as follows:

* Two PowerShell functions, Get-ResourcePoolByName and Set-ResourcePoolReservation, have been added to the utility script for VMware vSphere resource pool management. These functions facilitate the retrieval and modification of resource pool settings in an automated and reliable manner.


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Formatted the code** using VSCode default formatter for PowerShell.
* [X] **Tested the code** end-to-end against an SDDC.
* [X] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

