### PR TITLE
Create virtual machines's snapshot in Quiesce mode on a given VMFS datastore

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -81,7 +81,8 @@
         "Get-VmfsDatastore",
         "Get-VmfsHosts",
         "Get-StorageAdapters",
-        "Get-VmKernelAdapters"
+        "Get-VmKernelAdapters",
+        "New-VmfsVmSnapshot"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
This PR will enable user to create an application consistent VMFS datastore snapshot.  On a given datastore,  all running application and guest OS I/O are flushed on the vmdk file before a virtual machines snapshot is created. Ideally this command should be invoked to create virtual machines snaphost so that backed storage system create a consistent snapshot for restore operations. 


The changes in this PR are as follows:

* Collects VMs on a given datastore 
* Snapshot is create for each VM in a quiesce mode (no pending writes) 

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

