### PR TITLE
Adding back NVMe/TCP related functions

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -84,7 +84,8 @@
         "Get-VmKernelAdapters",
         "Connect-NVMeTCPTarget",
         "Disconnect-NVMeTCPTarget",
-        "Set-NVMeTCP"
+        "Set-NVMeTCP",
+        "New-NVMeTCPAdapter"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -81,7 +81,10 @@
         "Get-VmfsDatastore",
         "Get-VmfsHosts",
         "Get-StorageAdapters",
-        "Get-VmKernelAdapters"
+        "Get-VmKernelAdapters",
+        "Connect-NVMeTCPTarget",
+        "Disconnect-NVMeTCPTarget",
+        "Set-NVMeTCP",
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -84,7 +84,7 @@
         "Get-VmKernelAdapters",
         "Connect-NVMeTCPTarget",
         "Disconnect-NVMeTCPTarget",
-        "Set-NVMeTCP",
+        "Set-NVMeTCP"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
Previously, a PR was merged to remove NVMe/TCP specific functions name to avoid unintentional mistake. This PR will bring back those changes so that  existing functions work as expected for NVMe/TCP related storage operations.  

The changes in this PR are as follows:

* Adding back functions name (declaration) 
* ...


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

