### PR TITLE
Update Get-Host and Get-Datastore RunCommands to return related host(s) and datastore(s)

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1176,6 +1176,7 @@ function Get-VmfsDatastore {
     $NamedOutputs = @{}
 
     foreach ($Datastore in $Datastores){
+      $Hosts = Get-VMHost -Datastore $Datastore.Name | Select-Object select -ExpandProperty Name -ErrorAction Ignore
       $VmfsUuid = $Datastore.ExtensionData.info.Vmfs.uuid
       $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname;
       $NamedOutputs[$Datastore.Name] = "
@@ -1187,6 +1188,7 @@ function Get-VmfsDatastore {
            UUID : $($VmfsUuid),
            Device : $($HostViewDiskName),
            State : $($Datastore.State),
+           Hosts : $($Hosts),
            }"
     }
 
@@ -1245,7 +1247,7 @@ function Get-VmfsHosts {
     $VmHosts = $Cluster | Get-VMHost
 
     foreach ($VmHost in $VmHosts) {
-
+     $Datastores = $VmHost | Get-Datastore | Where-Object { $_.Type -match "VMFS" } | Select-Object select -ExpandProperty Name 
      $NamedOutputs[$VmHost.Name] = "
      {
       Name : $($VmHost.Name),
@@ -1255,7 +1257,7 @@ function Get-VmfsHosts {
       State : $($VmHost.State),
       HostNQN : $($VmHost.ExtensionData.Hardware.SystemInfo.QualifiedName.Value),
       Uuid : $($VmHost.ExtensionData.Hardware.SystemInfo.Uuid),
-      Datastores: $($VmHost.ExtensionData.Datastore),
+      Datastores: $($Datastores),
       Extension : $($VmHost.ExtensionData.config.StorageDevice.NvmeTopology | ConvertTo-JSON -Depth 2)
      }"
    }


### PR DESCRIPTION
This PR modify RunCommands  Get-VmfsDatastore and Get-VmfsHosts , these two commands are used heavily by current datastore orchestration workflows.  This change will let command user know the details about each datastore along with list of host currently accessing the datastore.  Similarly each  Host will return list of accessible datastore's names.


The changes in this PR are as follows:

* ... Each ESXi host will return names of all accessible active datastore(s).
* ... Each datastore will return names of all host(s) currently accessing this datastore.
* ...

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

