### PR TITLE
RunCommand Register Host with Static Discovery

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -69,6 +69,7 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
         "Set-VmfsIscsi",
+        "Set-VmfsStaticIscsi",
         "New-VmfsDatastore",
         "Dismount-VmfsDatastore",
         "Resize-VmfsVolume",


### PR DESCRIPTION

This PR closes #

Add a new RunCommand "Set-VmfsStaticIscsi" to set a static iSCSI target and apply best practices settings to the created iSCSI target

The changes in this PR are as follows:

* Add a RunCommand API Set-VmfsStatic iscsi that added iSCSI static targets to AVS

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Formatted the code** using VSCode default formatter for PowerShell.
* [X] **Tested the code** end-to-end against an SDDC.
Tested using on-premise deployment of vCenter and an AVS instance. 
* [X] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

