### PR TITLE
Add RunCommands for registering/unregistering a PureStorage plugin

### DIFF
--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
@@ -78,7 +78,9 @@
         "Start-ReplicationFailover",
         "Stop-ReplicationTestFailover",
         "Start-ReplicationReverse",
-        "Sync-ReplicationGroup"
+        "Sync-ReplicationGroup",
+        "Unregister-PureStorageAvsRemotePlugin",
+        "Register-PureStorageAvsRemotePlugin"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
Add RunCommands for registering/unregistering a PureStorage plugin

This PR closes #

The changes in this PR are as follows:
Add RunCommands for registering/unregistering a PureStorage plugin. 
The new RunCommands are 
* Register-PureStorageAvsRemotePlugin
* Unregister-PureStorageAvsRemotePlugin

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
     Tested using on-premise deployment
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

