### PR TITLE
Adding modules of expand esan datastore

### DIFF
--- a/Microsoft.AVS.ElasticSanDatastores/Microsoft.AVS.ElasticSanDatastores.psd1
+++ b/Microsoft.AVS.ElasticSanDatastores/Microsoft.AVS.ElasticSanDatastores.psd1
@@ -1,0 +1,130 @@
+#
+# Module manifest for module 'Microsoft.AVS.ElasticSanDatastores'
+#
+
+@{
+
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'Microsoft.AVS.ElasticSanDatastores.psm1'
+
+    # Version number of this module.
+    ModuleVersion = '1.0.0'
+
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
+
+    # ID used to uniquely identify this module
+    GUID = '44a79f2b-25d5-480a-b577-abb7eac2fbbe'
+
+    # Author of this module
+    Author = 'Shivani Gupta'
+
+    # Company or vendor of this module
+    CompanyName = 'Microsoft Corporation'
+
+    # Copyright statement for this module
+    Copyright = '(c) Microsoft. All rights reserved.'
+
+    # Description of the functionality provided by this module
+    Description = 'Azure VMware Solutions Package to manage ElasticSAN based datastores.'
+
+    # Minimum version of the PowerShell engine required by this module
+    PowerShellVersion = '7.2'
+
+    # Name of the PowerShell host required by this module
+    # PowerShellHostName = ''
+
+    # Minimum version of the PowerShell host required by this module
+    # PowerShellHostVersion = ''
+
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
+
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # ClrVersion = ''
+
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules = @(
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "6.0.112" }
+    )
+
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
+
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
+
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
+
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
+
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = @(
+        "Expand-ElasticSanDatastore"
+    )
+
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = @()
+
+    # Variables to export from this module
+    VariablesToExport = '*'
+
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = @()
+
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
+
+    # List of all modules packaged with this module
+    # ModuleList = @()
+
+    # List of all files packaged with this module
+    # FileList = @()
+
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
+
+    #Support for PowerShellGet galleries.
+        PSData = @{
+        # Tags applied to this module. These help with module discovery in online galleries.
+            Tags = @("VMware", "PowerCLI", "Azure", "AVS")
+
+            # A URL to the license for this module.
+            # LicenseUri = ''
+
+            # A URL to the main website for this project.
+            ProjectUri = 'https://github.com/Azure/Microsoft.AVS.Management'
+
+            # A URL to an icon representing this module.
+            # IconUri = ''
+
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
+
+            # Remove this for GA version
+            # Prerelease = ''
+
+            # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+            # RequireLicenseAcceptance = $false
+
+            # External dependent modules of this module
+            # ExternalModuleDependencies = @()
+        }
+
+    }
+
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
+
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
+
+}

--- a/Microsoft.AVS.ElasticSanDatastores/Microsoft.AVS.ElasticSanDatastores.psm1
+++ b/Microsoft.AVS.ElasticSanDatastores/Microsoft.AVS.ElasticSanDatastores.psm1
@@ -2,9 +2,6 @@
     .SYNOPSIS
      This function expands an ElasticSAN datastore capacity in AVS vCenter.
 
-    .PARAMETER ClusterName
-     Cluster name
-
     .PARAMETER DatastoreName
      Name of the ElasticSAN datastore to be expanded.
 
@@ -19,15 +16,8 @@
 #>
 function Expand-ElasticSanDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $false)]
     Param (
-        [Parameter(
-            Mandatory=$true,
-            HelpMessage = 'Cluster name in vCenter')]
-        [ValidateNotNull()]
-        [String]
-        $ClusterName,
-
         [Parameter(
             Mandatory=$true,
             HelpMessage = 'Name of the ElasticSAN based datastore as seen on vCenter')]
@@ -40,13 +30,7 @@ function Expand-ElasticSanDatastore {
         throw "Invalid datastore name $DatastoreName provided."
     }
 
-    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
-    if (-not $Cluster) {
-        throw "Cluster $ClusterName does not exist."
-    }
-
-    Write-Host "Retrieved cluster $ClusterName information. Searching for input datastore."
-    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba | Out-Null
+    Write-Host "Expand-ElasticSanDatastore command issued. Retrieving datastores to search for $DatastoreName"
     $Datastores = Get-Datastore -Name $DatastoreName -ErrorAction stop
     Write-Host "Retrieved list of datastores. Searching for the desired datastore for expand operation."
 

--- a/Microsoft.AVS.ElasticSanDatastores/Microsoft.AVS.ElasticSanDatastores.psm1
+++ b/Microsoft.AVS.ElasticSanDatastores/Microsoft.AVS.ElasticSanDatastores.psm1
@@ -1,0 +1,78 @@
+<#
+    .SYNOPSIS
+     This function expands an ElasticSAN datastore capacity in AVS vCenter.
+
+    .PARAMETER ClusterName
+     Cluster name
+
+    .PARAMETER DatastoreName
+     Name of the ElasticSAN datastore to be expanded.
+
+    .EXAMPLE
+     Expand-ElasticSanDatastore -ClusterName Cluster-1 -DatastoreName MyElasticSanDatastore
+
+    .INPUTS
+     vCenter cluster name, Name of the ElasticSAN datastore.
+
+    .OUTPUTS
+     None.
+#>
+function Expand-ElasticSanDatastore {
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
+    Param (
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Cluster name in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $ClusterName,
+
+        [Parameter(
+            Mandatory=$true,
+            HelpMessage = 'Name of the ElasticSAN based datastore as seen on vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $DatastoreName
+    )
+
+    if (-not $DatastoreName) {
+        throw "Invalid datastore name $DatastoreName provided."
+    }
+
+    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
+    if (-not $Cluster) {
+        throw "Cluster $ClusterName does not exist."
+    }
+
+    Write-Host "Retrieved cluster $ClusterName information. Searching for input datastore."
+    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba | Out-Null
+    $Datastores = Get-Datastore -Name $DatastoreName -ErrorAction stop
+    Write-Host "Retrieved list of datastores. Searching for the desired datastore for expand operation."
+
+    foreach ($Datastore in $Datastores) {
+        $CurrentDatastoreName = $Datastore.Name
+
+        if ($CurrentDatastoreName -eq $DatastoreName) {
+            Write-Host "Found the datastore to expand."
+            $DatastoreToResize = $Datastore
+            break
+        }
+    }
+
+    if (-not $DatastoreToResize) {
+        throw "Input datastore $DatastoreName was not found."
+    }
+
+    foreach ($DatastoreHost in $DatastoreToResize.ExtensionData.Host.Key) {
+      Get-VMHost -id "HostSystem-$($DatastoreHost.value)" | Get-VMHostStorage -RescanAllHba -RescanVmfs -ErrorAction Stop -WarningAction SilentlyContinue | Out-Null
+    }
+
+    Write-Host "Rescanned all HBAs. Getting expansion options."
+    $Esxi = Get-View -Id ($DatastoreToResize.ExtensionData.Host | Select-Object -last 1 | Select-Object -ExpandProperty Key)
+    $DatastoreSystem = Get-View -Id $Esxi.ConfigManager.DatastoreSystem
+    $ExpandOptions = $DatastoreSystem.QueryVmfsDatastoreExpandOptions($DatastoreToResize.ExtensionData.MoRef)
+
+    Write-Host "Expanding the size of the VMFS datastore."
+    $DatastoreSystem.ExpandVmfsDatastore($DatastoreToResize.ExtensionData.MoRef, $ExpandOptions[0].spec)
+}


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* We want to provide RunCommand based experience for ElasticSAN customers to expand their ElasticSAN datastore, once they expand their ElasticSAN volume in Azure Portal.
* Creates a new module, and a new cmdlet `Expand-ElasticSanDatastore` for expanding ElasticSAN based datastores for AVS.
* We do have a `Resize-VmfsVolume` cmdlet in Microsoft.AVS.VMFS, but the GA version of the package is tied to Pure Storage GA. This GA version only allows customers to execute the cmdlets necessary for Pure Storage CBS appliance integration. Hence it can't be used for ElasticSAN use cases.
* The new `Expand-ElasticSanDatastore` accepts ElasticSAN datastore name and cluster name to identify the datastore and expand it.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

