### PR TITLE
RunCommand to reconfigure HA

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -87,7 +87,8 @@
         "Disconnect-NVMeTCPTarget",
         "Set-NVMeTCP",
         "New-NVMeTCPAdapter",
-        "New-VmfsVmSnapshot"
+        "New-VmfsVmSnapshot",
+        "Repair-HAConfiguration"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION

This PR closes #

The changes in this PR are as follows:

Add new RunCommand Repait-HAConfiguration to enable re-configuring HA

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
Tested using on-premise deployment and manually using an SDDC instance
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

