### PR TITLE
Verify Certificates Downloaded from Domain Controllers in New-LDAPSIdentitySource

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -284,7 +284,7 @@ function Get-CertificateFromServerToLocalFile {
             catch {
                 throw "The FQDN $($ResultUrl.Host) cannot be resolved to an IP address. Make sure DNS is configured."
             }
-            Write-Host "Connectivity to $($ResultUrl.Host) is verified."
+            Write-Host "The FQDN $($ResultUrl.Host) is resolved successfully."
             try {
                 $Command = 'nc -vz ' + $ResultUrl.Host + ' ' + $ResultUrl.Port
                 $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
@@ -632,7 +632,7 @@ function New-LDAPSIdentitySource {
         if (($cert.NotBefore -lt $currentDate) -and ($cert.NotAfter -gt $currentDate)) {
             Write-Host "The certificate is current."
         } else {
-            Write-Error "The certificate is expired. The certificate is only valid not after $certDate." -ErrorAction Stop
+            Write-Error "The certificate is not current. It's only valid between $($cert.NotBefore) and $($cert.NotAfter)." -ErrorAction Stop
         }
     }
 

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -616,9 +616,9 @@ function New-LDAPSIdentitySource {
     }
 
     [System.Array]$Certificates =
-    foreach ($CertFile in $DestinationFileArray) {
+    foreach ($certFile in $DestinationFileArray) {
         try {
-            [System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromCertFile($certfile)
+            New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certfile)
         }
         catch {
             Write-Error "Failure to convert file $certfile to a certificate $($PSItem.Exception.Message)"

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -658,7 +658,7 @@ function New-LDAPSIdentitySource {
         -Certificates $Certificates -ErrorAction Stop
     }
     catch {
-        Write-Error "VCenter wasn't able to add this identity source: $_"
+        Write-Error "VCenter wasn't able to add this identity source: $_" -ErrorAction Stop
     }
     $ExternalIdentitySources = Get-IdentitySource -External -ErrorAction Continue
     $ExternalIdentitySources | Format-List | Out-String

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -630,11 +630,11 @@ function New-LDAPSIdentitySource {
             throw "File to certificate conversion failed. See error message for more details"
         }
     }
-
+    # check if the certicates expire or not
     foreach ($cert in $Certificates) {
         $certDate = Get-Date $cert.GetExpirationDateString()
         $currentDate = Get-Date
-        Write-Host "Verifying certificate: $cert"
+        Write-Host "Verifying certificate: $($cert.Subject)"
         if ($certDate -lt $currentDate) {
             Write-Error "The certificate is expired. The certificate is only valid not after $certDate." -ErrorAction Stop
         } else {


### PR DESCRIPTION
The changes in this PR are as follows:

* Verify the duration of certificates before adding a new ldapsIdentitySource.
* Print messages after each step in New-LDAPSIdentitySource

Testing: 

![image](https://github.com/Azure/Microsoft.AVS.Management/assets/60164697/14bd95e8-a8cb-47ea-9fe1-e5f17cad5730)




