### PR TITLE
RunCommand to clean disconnected iSCSI targets

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -88,7 +88,8 @@
         "Set-NVMeTCP",
         "New-NVMeTCPAdapter",
         "New-VmfsVmSnapshot",
-        "Repair-HAConfiguration"
+        "Repair-HAConfiguration",
+        "Clear-DisconnectedIscsiTargets"
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
RunCommand to clean disconnected iSCSI targets

The changes in this PR are as follows:

* Clear dynamic and iSCSI targets for dead arrays

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
Tested using on-premise deployment

* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.
