### PR TITLE
RunCommand to test VMKernel connectivity

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -89,6 +89,8 @@
         "New-NVMeTCPAdapter",
         "New-VmfsVmSnapshot",
         "Repair-HAConfiguration",
+        "Test-VMKernelConnectivity",
+        "Repair-HAConfiguration",
         "Clear-DisconnectedIscsiTargets"
     )
 

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1958,8 +1958,7 @@ function Clear-DisconnectedIscsiTargets {
 
 function Test-VMKernelConnectivity {
     [CmdletBinding()]
-
-
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param
     (
         [Parameter(

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -1941,3 +1941,67 @@ function Clear-DisconnectedIscsiTargets {
         }
     }
 }
+<#
+    .SYNOPSIS
+     This function checks each cluster host connectivity to vmkernel interface
+
+    .PARAMETER ClusterName
+     vSphere Cluster Name
+
+    .EXAMPLE
+     Test-VMKernelConnectivity -ClusterName "vSphere-cluster-001"
+
+    .INPUTS
+     vSphere Cluster Name, Storage VMKernel name
+
+#>
+
+function Test-VMKernelConnectivity {
+    [CmdletBinding()]
+
+
+    Param
+    (
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'vSphere Cluster Name')]
+        [String] $ClusterName
+    )
+
+    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
+    if (-not $Cluster) {
+        throw "Cluster $($ClusterName) does not exist."
+    }
+
+    $VMHosts = $null
+    try {
+        $VMHosts = Get-Cluster $ClusterName | Get-VMHost
+    }
+    catch {
+        Write-Host "Failed to collect cluster hosts $($_.Exception)"
+        throw "Failed to collect cluster hosts $($_.Exception)"
+    }
+
+    $Success = $true
+    foreach ($VMHost in $VMHosts) {
+        $HostAddress = $VMHost.Name
+        $NetworkInterfaces =  Get-VMHostNetworkAdapter -VMHost $VMHost | Where-Object {$_.Ip}
+        foreach ($Nic in $NetworkInterfaces) {
+            Write-Host "Checking connectivity to vmkernel interface $($Nic.Name) with address $($Nic.IP) on host $HostAddress"
+            $esxcli = Get-EsxCli -VMHost $VMHost.Name -V2
+            $params = $esxcli.network.diag.ping.CreateArgs()
+            $params.host = $Nic.IP
+            $result = $esxcli.network.diag.ping.Invoke($params)
+            if ($result.Summary.Received -gt 0) {
+                Write-Host "Ping to vmkernel interface $($VmKernel) on host $HostAddress is successful"
+            }
+            else {
+                Write-Error "Ping to vmkernel interface $($VmKernel) on host $HostAddress failed"
+                $Success = $false
+            }
+        }
+    }
+    if (-not $Success) {
+        throw "Ping to vmkernel interface failed on one or more hosts"
+    }
+}


### PR DESCRIPTION

RunCommand to test VMKernel connectivity

The changes in this PR are as follows:

* Add a RunCommand to check vmkernel connectivity for a given cluster

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
Tested using on-premise deployment
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

