### PR TITLE
Remove check to allow restoring VMFS datastore on flash and non-flash

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -35,14 +35,14 @@ function Set-VmfsIscsi {
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Primary IP Address to add as dynamic iSCSI target')]
         [ValidateNotNull()]
         [String]
@@ -89,8 +89,8 @@ function Set-VmfsIscsi {
             $VMHost | Get-VMHostStorage | Set-VMHostStorage -SoftwareIScsiEnabled $True | Out-Null
         }
 
-        $IscsiAdapter = $VMHost | Get-VMHostHba -Type iScsi | Where-Object {$_.Model -eq "iSCSI Software Adapter"}
-        if (!(Get-IScsiHbaTarget -IScsiHba $IscsiAdapter -Type Send -ErrorAction stop | Where-Object {$_.Address -cmatch $ScsiIpAddress})) {
+        $IscsiAdapter = $VMHost | Get-VMHostHba -Type iScsi | Where-Object { $_.Model -eq "iSCSI Software Adapter" }
+        if (!(Get-IScsiHbaTarget -IScsiHba $IscsiAdapter -Type Send -ErrorAction stop | Where-Object { $_.Address -cmatch $ScsiIpAddress })) {
             New-IScsiHbaTarget -IScsiHba $IscsiAdapter -Address $ScsiIpAddress -ErrorAction stop
         }
 
@@ -100,7 +100,7 @@ function Set-VmfsIscsi {
         $IscsiArgs.address = $ScsiIpAddress
 
         function Set-IscsiConfig($Name, $Value) {
-            $CurrentValue = $EsxCli.iscsi.adapter.discovery.sendtarget.param.get.invoke($IscsiArgs) | Where-Object {$_.name -eq $Name}
+            $CurrentValue = $EsxCli.iscsi.adapter.discovery.sendtarget.param.get.invoke($IscsiArgs) | Where-Object { $_.name -eq $Name }
             if ($CurrentValue.Current -ne $Value) {
                 $IscsiArgs = $EsxCli.iscsi.adapter.discovery.sendtarget.param.set.CreateArgs()
                 $IscsiArgs.adapter = $IscsiAdapter.Device
@@ -115,140 +115,6 @@ function Set-VmfsIscsi {
         Set-IscsiConfig -Name "LoginTimeout" -Value $LoginTimeout
         Set-IscsiConfig -Name "NoopOutTimeout" -Value $NoopOutTimeout
         Set-IscsiConfig -Name "RecoveryTimeout" -Value $RecoveryTimeout
-    }
-
-    Write-Host "Successfully configured VMFS iSCSI for cluster $ClusterName."
-}
-
-<#
-    .SYNOPSIS
-     This function updates all hosts in the specified cluster to have the following iSCSI configurations:
-
-     1. SCSI IP address are added as static iSCSI addresses.
-     2. iSCSI Software Adapter is enabled.
-     3. Apply iSCSI best practices configuration on static targets.
-
-    .PARAMETER ClusterName
-     Cluster name
-
-    .PARAMETER ScsiIpAddress
-     IP Address to add as static iSCSI target
-
-     .PARAMETER ScsiName
-     iSCSI target name
-
-     .PARAMETER LoginTimeout
-     Optional. Login timeout in seconds (default 30)
-
-    .PARAMETER NoopOutTimeout
-    Optional. NoopOut timeout in seconds (default 30)
-
-    .PARAMETER RecoveryTimeout
-    Optional. Recovery timeout in seconds (default 45)
-
-    .EXAMPLE
-     Set-VmfsIscsi -ClusterName "myCluster" -ScsiIpAddress "192.168.0.1" -IscsitName "iqn.1998-01.com.vmware:target-1"
-
-    .INPUTS
-     vCenter cluster name, Primary SCSI IP Addresses. iSCSI target name
-
-    .OUTPUTS
-     None.
-#>
-function Set-VmfsStaticIscsi {
-    [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
-    Param (
-        [Parameter(
-            Mandatory = $true,
-            HelpMessage = 'Cluster name in vCenter')]
-        [ValidateNotNull()]
-        [String]
-        $ClusterName,
-
-        [Parameter(
-            Mandatory = $true,
-            HelpMessage = 'Primary IP Address to add as static iSCSI target')]
-        [ValidateNotNull()]
-        [String]
-        $ScsiIpAddress,
-
-        [Parameter(
-            Mandatory = $true,
-            HelpMessage = 'iSCSI target name')]
-        [String] $ScsiName,
-
-        [Parameter (
-            Mandatory = $false,
-            HelpMessage = 'Login timeout in seconds'
-        )]
-        [ValidateRange(1, 60)]
-        [int] $LoginTimeout = 30,
-
-        [Parameter (
-            Mandatory = $false,
-            HelpMessage = 'NoopOut timeout in seconds'
-        )]
-        [ValidateRange(10, 30)]
-        [int] $NoopOutTimeout = 30,
-
-        [Parameter (
-            Mandatory = $false,
-            HelpMessage = 'Recovery timeout in seconds'
-        )]
-        [ValidateRange(1, 120)]
-        [int] $RecoveryTimeout = 45
-    )
-    try {
-        [ipaddress] $ScsiIpAddress
-    }
-    catch {
-        throw "Invalid SCSI IP address $ScsiIpAddress provided."
-    }
-
-    $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
-    if (-not $Cluster) {
-        throw "Cluster $ClusterName does not exist."
-    }
-
-    $VMHosts = $Cluster | Get-VMHost
-    foreach ($VMHost in $VMHosts) {
-        $Iscsi = $VMHost | Get-VMHostStorage
-        if ($Iscsi.SoftwareIScsiEnabled -ne $true) {
-            $VMHost | Get-VMHostStorage | Set-VMHostStorage -SoftwareIScsiEnabled $True | Out-Null
-        }
-
-        $IscsiAdapter = $VMHost | Get-VMHostHba -Type iScsi | Where-Object { $_.Model -eq "iSCSI Software Adapter" }
-        if (!(Get-IScsiHbaTarget -IScsiHba $IscsiAdapter -Type "Static" -ErrorAction stop | Where-Object { $_.Address -cmatch $ScsiIpAddress })) {
-            New-IScsiHbaTarget -IScsiHba $IscsiAdapter -Type "Static" -Address $ScsiIpAddress -IScsiName $ScsiName -ErrorAction stop
-            Write-Verbose "Added static iSCSI target $ScsiName with address $ScsiIpAddress to $VMHost"
-        }
-
-        $EsxCli = $VMHost | Get-EsxCli -v2
-
-        function Set-StaticIscsiConfig($Name, $Value) {
-            $IscsiArgs = $EsxCli.iscsi.adapter.target.portal.param.get.CreateArgs()
-            $IscsiArgs.adapter = $IscsiAdapter.Device
-            $IscsiArgs.address = $ScsiIpAddress
-            $IscsiArgs.name = $ScsiName
-            $CurrentValue = $EsxCli.iscsi.adapter.target.portal.param.get.invoke($IscsiArgs) | Where-Object { $_.name -eq $Name }
-            if ($CurrentValue.Current -ne $Value) {
-                $IscsiArgs = $EsxCli.iscsi.adapter.target.portal.param.set.CreateArgs()
-                $IscsiArgs.adapter = $IscsiAdapter.Device
-                $IscsiArgs.address = $ScsiIpAddress
-                $IscsiArgs.name = $ScsiName
-                $IscsiArgs.inherit = $false
-                $IscsiArgs.value = $Value
-                $IscsiArgs.key = $Name
-                $EsxCli.iscsi.adapter.target.portal.param.set.invoke($IscsiArgs) | Out-Null
-                Write-verbose "Set $Name to $Value for $ScsiName"
-            }
-        }
-
-        Set-StaticIscsiConfig -Name "DelayedAck" -Value "false"
-        Set-StaticIscsiConfig -Name "LoginTimeout" -Value $LoginTimeout
-        Set-StaticIscsiConfig -Name "NoopOutTimeout" -Value $NoopOutTimeout
-        Set-StaticIscsiConfig -Name "RecoveryTimeout" -Value $RecoveryTimeout
     }
 
     Write-Host "Successfully configured VMFS iSCSI for cluster $ClusterName."
@@ -284,28 +150,28 @@ function New-VmfsDatastore {
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Name of VMFS datastore to be created in vCenter')]
         [ValidateNotNull()]
         [String]
         $DatastoreName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'NAA ID of device used to create a new VMFS datastore')]
         [ValidateNotNull()]
         [String]
         $DeviceNaaId,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Capacity of new datastore in bytes')]
         [ValidateNotNull()]
         [String]
@@ -314,7 +180,8 @@ function New-VmfsDatastore {
 
     try {
         $SizeInBytes = [UInt64] $Size
-    } catch {
+    }
+    catch {
         throw "Invalid Size $Size provided."
     }
 
@@ -338,7 +205,7 @@ function New-VmfsDatastore {
 
         $TotalSectors = $SizeInBytes / 512
         $Esxi = $Cluster | Get-VMHost | Where-Object { ($_.ConnectionState -eq 'Connected') } | Select-Object -last 1
-        $EsxiView = Get-View -ViewType HostSystem -Filter @{"Name" = $Esxi.name}
+        $EsxiView = Get-View -ViewType HostSystem -Filter @{"Name" = $Esxi.name }
         $DatastoreSystem = Get-View -Id $EsxiView.ConfigManager.DatastoreSystem
         $Device = $DatastoreSystem.QueryAvailableDisksForVmfs($null) | Where-Object { ($_.CanonicalName -eq $DeviceNaaId) }
         $DatastoreCreateOptions = $DatastoreSystem.QueryVmfsDatastoreCreateOptions($Device.DevicePath, $null)
@@ -359,11 +226,12 @@ function New-VmfsDatastore {
         $VmfsDatastoreCreateSpec.vmfs.MajorVersion = $DatastoreCreateOptions[0].Spec.Vmfs.MajorVersion
 
         $DatastoreSystem.CreateVmfsDatastore($VmfsDatastoreCreateSpec)
-    } catch {
+    }
+    catch {
         Write-Error $Global:Error[0]
     }
 
-    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba | Out-Null
+    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba -RescanVmfs | Out-Null
     $Datastore = Get-Datastore -Name $DatastoreName -ErrorAction Ignore
     if (-not $Datastore -or $Datastore.type -ne "VMFS") {
         throw "Failed to create datastore $DatastoreName."
@@ -394,14 +262,14 @@ function Dismount-VmfsDatastore {
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Name of VMFS datastore to be unmounted in vCenter')]
         [ValidateNotNull()]
         [String]
@@ -424,11 +292,11 @@ function Dismount-VmfsDatastore {
     Write-Host "Unmounting datastore $DatastoreName from all hosts, detaching SCSI devices, NVMe/TCP devices are not detached."
     $VMHosts = $Cluster | Get-VMHost
     foreach ($VMHost in $VMHosts) {
-        $IsDatastoreConnectedToHost = Get-Datastore -VMHost $VMHost | Where-Object {$_.name -eq $DatastoreName}
+        $IsDatastoreConnectedToHost = Get-Datastore -VMHost $VMHost | Where-Object { $_.name -eq $DatastoreName }
         if ($null -ne $IsDatastoreConnectedToHost) {
             $VMs = $Datastore | Get-VM
             if ($VMs -and $VMs.Count -gt 0) {
-                $vmNames = $VMs | Join-String -SingleQuote -Property {$_.Name}  -Separator ", "
+                $vmNames = $VMs | Join-String -SingleQuote -Property { $_.Name }  -Separator ", "
                 throw "Cannot unmount datastore $DatastoreName. It is already in use by $vmNames."
             }
 
@@ -441,11 +309,11 @@ function Dismount-VmfsDatastore {
             Write-Host "Datastore unmounted."
 
             $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname;
-            if(($null -ne $HostViewDiskName) -and ($HostViewDiskName.StartsWith("eui."))){
-               Write-Host "Device UUID $($VmfsUuid) is an NVMe/TCP volume, not required to be detached, and can be mounted back to host as needed."
+            if (($null -ne $HostViewDiskName) -and ($HostViewDiskName.StartsWith("eui."))) {
+                Write-Host "Device UUID $($VmfsUuid) is an NVMe/TCP volume, not required to be detached, and can be mounted back to host as needed."
             }
             else {
-                  $HostStorageSystem.DetachScsiLun($ScsiLunUuid) | Out-Null
+                $HostStorageSystem.DetachScsiLun($ScsiLunUuid) | Out-Null
             }
             Write-Host "Rescanning now.."
             $VMHost | Get-VMHostStorage -RescanAllHba -RescanVmfs | Out-Null
@@ -477,14 +345,14 @@ function Resize-VmfsVolume {
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'NAA ID of device associated with the existing VMFS volume')]
         [ValidateNotNull()]
         [String]
@@ -516,7 +384,7 @@ function Resize-VmfsVolume {
     }
 
     foreach ($DatastoreHost in $DatastoreToResize.ExtensionData.Host.Key) {
-      Get-VMHost -id "HostSystem-$($DatastoreHost.value)" | Get-VMHostStorage -RescanAllHba -RescanVmfs -ErrorAction Stop -WarningAction SilentlyContinue | Out-Null
+        Get-VMHost -id "HostSystem-$($DatastoreHost.value)" | Get-VMHostStorage -RescanAllHba -RescanVmfs -ErrorAction Stop -WarningAction SilentlyContinue | Out-Null
     }
 
     $Esxi = Get-View -Id ($DatastoreToResize.ExtensionData.Host | Select-Object -last 1 | Select-Object -ExpandProperty Key)
@@ -554,14 +422,14 @@ function Restore-VmfsVolume {
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-            Mandatory=$true,
+            Mandatory = $true,
             HelpMessage = 'NAA ID of device associated with the existing VMFS volume')]
         [ValidateNotNull()]
         [String]
@@ -574,9 +442,6 @@ function Restore-VmfsVolume {
         $DatastoreName
     )
 
-    if ($DeviceNaaId -notlike 'naa.624a9370*') {
-        throw "Invalid Device NAA ID $DeviceNaaId provided."
-    }
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
     if (-not $Cluster) {
@@ -603,11 +468,12 @@ function Restore-VmfsVolume {
                     if ($ResigVolume.ResolveStatus.MultipleCopies -eq $true) {
                         Write-Error "The volume cannot be re-signatured as more than one non re-signatured copy is present."
                         Write-Error "The following volume(s) need to be removed/re-signatured first:"
-                        $ResigVolume.Extent.Device.DiskName | Where-Object {$_ -ne $DeviceNaaId}
+                        $ResigVolume.Extent.Device.DiskName | Where-Object { $_ -ne $DeviceNaaId }
                     }
 
                     throw "Failed to re-signature VMFS volume."
-                } else {
+                }
+                else {
                     $VolumeToResignature = $ResigVolume
                     break
                 }
@@ -665,8 +531,8 @@ function Sync-VMHostStorage {
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
-                Mandatory=$true,
-                HelpMessage = 'VMHost name')]
+            Mandatory = $true,
+            HelpMessage = 'VMHost name')]
         [ValidateNotNull()]
         [String]
         $VMHostName
@@ -696,8 +562,8 @@ function Sync-ClusterVMHostStorage {
     [AVSAttribute(10, UpdatesSDDC = $false)]
     Param (
         [Parameter(
-                Mandatory=$true,
-                HelpMessage = 'Cluster name in vCenter')]
+            Mandatory = $true,
+            HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName
@@ -735,15 +601,15 @@ function Remove-VMHostStaticIScsiTargets {
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
     Param (
         [Parameter(
-                Mandatory=$true,
-                HelpMessage = 'Cluster name in vCenter')]
+            Mandatory = $true,
+            HelpMessage = 'Cluster name in vCenter')]
         [ValidateNotNull()]
         [String]
         $ClusterName,
 
         [Parameter(
-                Mandatory=$true,
-                HelpMessage = 'IP Address of static iSCSI target to remove. Multiple addresses can be seperated by ","')]
+            Mandatory = $true,
+            HelpMessage = 'IP Address of static iSCSI target to remove. Multiple addresses can be seperated by ","')]
         [ValidateNotNull()]
         [String]
         $iSCSIAddress
@@ -757,7 +623,7 @@ function Remove-VMHostStaticIScsiTargets {
     $iSCSIAddressList = $iSCSIAddress.Split(",")
 
     # Remove iSCSI ip address from static discovery from all of hosts if there is a match
-    $Cluster | Get-VMHost | Get-VMHostHba -Type iScsi | Get-IScsiHbaTarget | Where-Object {($_.Type -eq "Static") -and ($ISCSIAddressList -contains $_.Address)} | Remove-IScsiHbaTarget -Confirm:$false
+    $Cluster | Get-VMHost | Get-VMHostHba -Type iScsi | Get-IScsiHbaTarget | Where-Object { ($_.Type -eq "Static") -and ($ISCSIAddressList -contains $_.Address) } | Remove-IScsiHbaTarget -Confirm:$false
 
     # Rescan after removing the iSCSI targets
     $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba -RescanVMFS | Out-Null
@@ -992,8 +858,8 @@ function Disconnect-NVMeTCPTarget {
             continue
         }
 
-        $ProvisionedDevices = Get-Datastore -VMHost $VmHost.Name | where-object{$_.ExtensionData.Info.Vmfs.Extent.DiskName -like  'eui.*'}
-        if(($Null -ne $ProvisionedDevices) -and ($ProvisionedDevices.Length -gt 0)){
+        $ProvisionedDevices = Get-Datastore -VMHost $VmHost.Name | where-object { $_.ExtensionData.Info.Vmfs.Extent.DiskName -like 'eui.*' }
+        if (($Null -ne $ProvisionedDevices) -and ($ProvisionedDevices.Length -gt 0)) {
             Write-Host "Storage device(s) found on host $($VmHost.Name) from target, skipping to disconnect."
             Write-Host ""
             continue
@@ -1100,13 +966,13 @@ function Remove-VmfsDatastore {
     }
 
     $AvailableDatastore = Get-Datastore -Name $DatastoreName -ErrorAction ignore
-    if ( (-not $AvailableDatastore)  -or ($AvailableDatastore.State -eq "Unavailable")) {
+    if ( (-not $AvailableDatastore) -or ($AvailableDatastore.State -eq "Unavailable")) {
         throw "Datastore $DatastoreName does not exist Or datastore is in Unvailable state."
 
     }
 
     $VMs = Get-VM -Datastore $DatastoreName -ErrorAction ignore
-    if ($VMs){
+    if ($VMs) {
         throw "Datastore $DatastoreName is hosting worker virtual machines and can't be deleted"
 
     }
@@ -1116,55 +982,55 @@ function Remove-VmfsDatastore {
 
     $DeleteDs = $true
 
-    foreach ($RltdHost in $RelatedVmHosts){
-            if($RltdHost.Parent.Name.Trim() -ne $ClusterName){
-                $DeleteDs = $false
-                break;
-            }
-    }
-
-   $IsDatastoreRemoved=$false
-   if($DeleteDs){
-    try {
-        Write-Host "Removing datastore using esxi host $($RelatedVmHosts[0].Name) as reference host."
-        Remove-Datastore -VMHost $RelatedVmHosts[0].Name -Datastore $DatastoreName -Confirm:$false
-        $AvailableDatastore = $null
-        $AvailableDatastore = Get-Datastore -Name $DatastoreName -ErrorAction ignore
-        if (-not $AvailableDatastore) {
-            Write-Host "Datastore removed. "
-            $IsDatastoreRemoved=$true
+    foreach ($RltdHost in $RelatedVmHosts) {
+        if ($RltdHost.Parent.Name.Trim() -ne $ClusterName) {
+            $DeleteDs = $false
+            break;
         }
     }
-    catch {
-        throw "Failed to remove datasore $($DatastoreName)."
-    }
-  }
 
- else{
-
-     Write-Host "Datastore is shared, Unmounting datastore from each host under the cluster $($ClusterName)"
-     $VmfsUuid = $AvailableDatastore.ExtensionData.info.Vmfs.uuid
-     foreach ($VmHost in $VMHosts) {
-
+    $IsDatastoreRemoved = $false
+    if ($DeleteDs) {
         try {
-            $HostStorageSystem = Get-View $VmHost.Extensiondata.ConfigManager.StorageSystem
-            $HostStorageSystem.UnmountVmfsVolume($VmfsUuid) | Out-Null
-
+            Write-Host "Removing datastore using esxi host $($RelatedVmHosts[0].Name) as reference host."
+            Remove-Datastore -VMHost $RelatedVmHosts[0].Name -Datastore $DatastoreName -Confirm:$false
+            $AvailableDatastore = $null
+            $AvailableDatastore = Get-Datastore -Name $DatastoreName -ErrorAction ignore
+            if (-not $AvailableDatastore) {
+                Write-Host "Datastore removed. "
+                $IsDatastoreRemoved = $true
+            }
         }
         catch {
-          Write-Host "Failed to unmount datastore from host "$VmHost.Name
+            throw "Failed to remove datasore $($DatastoreName)."
         }
-     }
-  }
+    }
 
-  Write-Host "Rescanning datastore "
-  $RescanResult = Get-VMHostStorage -VMHost $RelatedVmHosts[0].Name -RescanAllHba
+    else {
 
-  if (-not($IsDatastoreRemoved)){
+        Write-Host "Datastore is shared, Unmounting datastore from each host under the cluster $($ClusterName)"
+        $VmfsUuid = $AvailableDatastore.ExtensionData.info.Vmfs.uuid
+        foreach ($VmHost in $VMHosts) {
+
+            try {
+                $HostStorageSystem = Get-View $VmHost.Extensiondata.ConfigManager.StorageSystem
+                $HostStorageSystem.UnmountVmfsVolume($VmfsUuid) | Out-Null
+
+            }
+            catch {
+                Write-Host "Failed to unmount datastore from host "$VmHost.Name
+            }
+        }
+    }
+
+    Write-Host "Rescanning datastore "
+    $RescanResult = Get-VMHostStorage -VMHost $RelatedVmHosts[0].Name -RescanAllHba
+
+    if (-not($IsDatastoreRemoved)) {
         Write-Host "Datastore was found but did't remove, instead unmounted from ESXi hosts under the given cluster."
-   }
+    }
 
-   Write-Host " " ;
+    Write-Host " " ;
 
 }
 
@@ -1189,22 +1055,22 @@ function Remove-VmfsDatastore {
     None.
  #>
 function Mount-VmfsDatastore {
-  [CmdletBinding()]
-  [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
-  Param (
-         [ Parameter(
-            Mandatory=$true,
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
+    Param (
+        [ Parameter(
+            Mandatory = $true,
             HelpMessage = 'vSphere Cluster name in vCenter')]
-            [ValidateNotNull()]
-            [String]
-            $ClusterName,
-            [Parameter(
-                Mandatory=$true,
-                HelpMessage = 'Name of VMFS datastore to be mounted on host(s) in vCenter')]
-            [ValidateNotNull()]
-            [String]
-            $DatastoreName
-        )
+        [ValidateNotNull()]
+        [String]
+        $ClusterName,
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Name of VMFS datastore to be mounted on host(s) in vCenter')]
+        [ValidateNotNull()]
+        [String]
+        $DatastoreName
+    )
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
     if (-not $Cluster) {
@@ -1213,45 +1079,45 @@ function Mount-VmfsDatastore {
 
     $Datastore = Get-Datastore -Name $DatastoreName -ErrorAction Ignore
     if (-not $Datastore) {
-                throw "Datastore $DatastoreName does not exist."
+        throw "Datastore $DatastoreName does not exist."
     }
 
     if ("VMFS" -ne $Datastore.Type) {
-         throw "Datastore $DatastoreName is of type $($Datastore.Type). This cmdlet can only process VMFS datastores."
+        throw "Datastore $DatastoreName is of type $($Datastore.Type). This cmdlet can only process VMFS datastores."
     }
 
     Write-Host "Mounting datastore $DatastoreName to all host(s) in the given vSphere cluster."
 
     $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname
-    if ($null -eq $HostViewDiskName){
-         throw "Could't find backing device for the datastore $($DatastoreName)"
+    if ($null -eq $HostViewDiskName) {
+        throw "Could't find backing device for the datastore $($DatastoreName)"
     }
 
     $VmHosts = $Cluster | Get-VMHost
 
-    foreach ($VmHost in $VmHosts){
+    foreach ($VmHost in $VmHosts) {
 
-      $Devices = $VmHost.ExtensionData.config.StorageDevice.ScsiLun | Where-Object { $_.DevicePath -like "*$($HostViewDiskName)*" }
-      if ($null -eq $Devices){
-          Write-Host "Could't find device on ESXi host $($VmHost.Name) for device UUID  $($HostViewDiskName), skipping to mount datastore"
-         continue
-      }
+        $Devices = $VmHost.ExtensionData.config.StorageDevice.ScsiLun | Where-Object { $_.DevicePath -like "*$($HostViewDiskName)*" }
+        if ($null -eq $Devices) {
+            Write-Host "Could't find device on ESXi host $($VmHost.Name) for device UUID  $($HostViewDiskName), skipping to mount datastore"
+            continue
+        }
 
-      $HostView = Get-View $VmHost
-      $StorageSys = Get-View $HostView.ConfigManager.StorageSystem
-      Write-Host "Mounting VMFS Datastore $($Datastore.Name) on host $($HostView.Name)"
-      try{
-          $StorageSys.MountVmfsVolume($Datastore.ExtensionData.Info.vmfs.uuid);
-      }
-      catch{
-           Write-Error "Failed to VMFS Datastore $($Datastore.Name) on host $($HostView.Name)"
-      }
+        $HostView = Get-View $VmHost
+        $StorageSys = Get-View $HostView.ConfigManager.StorageSystem
+        Write-Host "Mounting VMFS Datastore $($Datastore.Name) on host $($HostView.Name)"
+        try {
+            $StorageSys.MountVmfsVolume($Datastore.ExtensionData.Info.vmfs.uuid);
+        }
+        catch {
+            Write-Error "Failed to VMFS Datastore $($Datastore.Name) on host $($HostView.Name)"
+        }
 
-      Write-Host "Datastore $($Datastore.Name) mounted successfully on host, rescanning now.. $($hostview.Name)."
-      $VmHost | Get-VMHostStorage -RescanAllHba -RescanVmfs | Out-Null
+        Write-Host "Datastore $($Datastore.Name) mounted successfully on host, rescanning now.. $($hostview.Name)."
+        $VmHost | Get-VMHostStorage -RescanAllHba -RescanVmfs | Out-Null
     }
 
-  }
+}
 
 
 <#
@@ -1273,14 +1139,14 @@ function Mount-VmfsDatastore {
 
 function Get-VmfsDatastore {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+   
 
     Param
     (
-      [Parameter(
+        [Parameter(
             Mandatory = $true,
             HelpMessage = 'vSphere Cluster Name')]
-      [string] $ClusterName
+        [string] $ClusterName
 
     )
 
@@ -1299,7 +1165,7 @@ function Get-VmfsDatastore {
     }
 
 
-    $Datastores = Get-VMHost -Name $VmHosts | Get-Datastore | Where-Object {$_.Type -match "VMFS"} | Get-Unique
+    $Datastores = Get-VMHost -Name $VmHosts | Get-Datastore | Where-Object { $_.Type -match "VMFS" } | Get-Unique
 
     if ( -not $Datastores) {
         Write-Host "No Datastore found under the given cluster."
@@ -1309,11 +1175,11 @@ function Get-VmfsDatastore {
 
     $NamedOutputs = @{}
 
-    foreach ($Datastore in $Datastores){
-      $Hosts = Get-VMHost -Datastore $Datastore.Name | Select-Object select -ExpandProperty Name -ErrorAction Ignore
-      $VmfsUuid = $Datastore.ExtensionData.info.Vmfs.uuid
-      $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname;
-      $NamedOutputs[$Datastore.Name] = "
+    foreach ($Datastore in $Datastores) {
+        $Hosts = Get-VMHost -Datastore $Datastore.Name | Select-Object select -ExpandProperty Name -ErrorAction Ignore
+        $VmfsUuid = $Datastore.ExtensionData.info.Vmfs.uuid
+        $HostViewDiskName = $Datastore.ExtensionData.Info.vmfs.extent[0].Diskname;
+        $NamedOutputs[$Datastore.Name] = "
            {
            Name : $($Datastore.Name),
            Capacity : $($Datastore.CapacityGB),
@@ -1326,19 +1192,19 @@ function Get-VmfsDatastore {
            }"
     }
 
-   if($NamedOutputs.Count -gt 0){
+    if ($NamedOutputs.Count -gt 0) {
 
-      Write-host $NamedOutputs | ConvertTo-Json -Depth 10
-   }
+        Write-host $NamedOutputs | ConvertTo-Json -Depth 10
+    }
 
-   Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
 
-   Write-Host " "
+    Write-Host " "
 
 }
 
 
-    <#
+<#
     .SYNOPSIS
      This function collects all ESXi host(s) along with detailed inventory under a given vSphere Cluster.
 
@@ -1357,7 +1223,7 @@ function Get-VmfsDatastore {
 
 function Get-VmfsHosts {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+    
 
     Param
     (
@@ -1381,8 +1247,8 @@ function Get-VmfsHosts {
     $VmHosts = $Cluster | Get-VMHost
 
     foreach ($VmHost in $VmHosts) {
-     $Datastores = $VmHost | Get-Datastore | Where-Object { $_.Type -match "VMFS" } | Select-Object select -ExpandProperty Name 
-     $NamedOutputs[$VmHost.Name] = "
+        $Datastores = $VmHost | Get-Datastore | Where-Object { $_.Type -match "VMFS" } | Select-Object select -ExpandProperty Name 
+        $NamedOutputs[$VmHost.Name] = "
      {
       Name : $($VmHost.Name),
       Version : $($VmHost.Version),
@@ -1394,11 +1260,11 @@ function Get-VmfsHosts {
       Datastores: $($Datastores),
       Extension : $($VmHost.ExtensionData.config.StorageDevice.NvmeTopology | ConvertTo-JSON -Depth 2)
      }"
-   }
+    }
 
 
-   Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
-   Write-Host ""
+    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+    Write-Host ""
 
 }
 
@@ -1422,7 +1288,7 @@ function Get-VmfsHosts {
 
 function Get-StorageAdapters {
     [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
+   
 
     Param
     (
@@ -1710,16 +1576,16 @@ function New-NVMeTCPAdapter {
 <#
     .SYNOPSIS
      This function collects all VMs on the provided datastore and creates snapshot of each virtual machine.
-
+    
     .PARAMETER -ClusterName
      vSphere Cluster Name
-
+    
     .PARAMETER -DatastoreName
      Datastore name
-
+     
 
     .EXAMPLE
-     New-VmfsVmSnapshot -ClusterName "vSphere-cluster-001" -DatastoreName "myDatastore"
+     New-VmfsVmSnapshot -ClusterName "vSphere-cluster-001" -DatastoreName "myDatastore"   
 
     .INPUTS
      vSphere cluster name, datastore name
@@ -1731,7 +1597,7 @@ function New-NVMeTCPAdapter {
 function New-VmfsVmSnapshot {
     [CmdletBinding()]
     [AVSAttribute(10, UpdatesSDDC = $false, AutomationOnly = $true)]
-
+    
     Param
     (
         [Parameter(
@@ -1758,14 +1624,14 @@ function New-VmfsVmSnapshot {
         throw "Datastore $DatastoreName does not exist."
     }
 
-
+      
     $NamedOutputs = @{}
     $Vms = Get-VM -Datastore $Datastore
 
     foreach ($Vm in $Vms) {
         $timeStamp = Get-Date -Format o | ForEach-Object { $_ -replace ":", "-" }
-        $SnapshotName = $Vm.Name + "-" + $timeStamp
-
+        $SnapshotName = $Vm.Name + "-" + $timeStamp 
+        
         if (!$Vm.ExtensionData) {
             Write-Host "Skipping to create snapshot of virtual machine $($Vm.Name), becuase of unavailable configuration."
             continue
@@ -1775,7 +1641,7 @@ function New-VmfsVmSnapshot {
             Write-Host "Skipping to create snapshot of virtual machine $($Vm.Name) becuase health status is not OK."
             continue
         }
-
+           
         try {
             $Snapshot = New-Snapshot -VM $Vm -Quiesce -Name $SnapshotName -ErrorAction Ignore
             Write-Host "Snapshot $($Snapshot.Name) created."
@@ -1786,7 +1652,7 @@ function New-VmfsVmSnapshot {
         }
     }
 
-    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global    
     Write-Host ""
-
+    
 }


### PR DESCRIPTION
This PR enables restoring VMFS datastore on flash and non-flash devices, removing the hard check that blocks restoring  datastore on flash devices. Also added a RescanVmfs to avoid Intermittent failure of device visibility to ESXi host. 

The changes in this PR are as follows:

... Remove a hard-check that blocks restoring datastore on non naa.* devices.
... Restore datastore on flash and non-flash devices.
... added a RescanVmfs to avoid Intermittent failure of device visibility.  


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

