### PR TITLE
Remove check to allow restoring VMFS datastore on flash and non-flash

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -363,7 +363,7 @@ function New-VmfsDatastore {
         Write-Error $Global:Error[0]
     }
 
-    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba | Out-Null
+    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba -RescanVmfs | Out-Null
     $Datastore = Get-Datastore -Name $DatastoreName -ErrorAction Ignore
     if (-not $Datastore -or $Datastore.type -ne "VMFS") {
         throw "Failed to create datastore $DatastoreName."
@@ -573,10 +573,6 @@ function Restore-VmfsVolume {
         [String]
         $DatastoreName
     )
-
-    if ($DeviceNaaId -notlike 'naa.624a9370*') {
-        throw "Invalid Device NAA ID $DeviceNaaId provided."
-    }
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
     if (-not $Cluster) {


### PR DESCRIPTION
This PR enables restoring VMFS datastore on flash and non-flash devices, removing the hard check that blocks restoring datastore on flash devices. Also added a RescanVmfs to avoid Intermittent failure of device visibility to ESXi host.

This PR closes #

The changes in this PR are as follows:

* ...  Remove a hard-check that blocks restoring datastore on non naa.* devices.
* ...  Restore datastore on flash and non-flash devices.
* ...  Added a RescanVmfs to avoid Intermittent failure of device visibility.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

