### PR TITLE
Allow specifying individual VMhost when cleaning iSCSI targets

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -769,12 +769,12 @@ function Remove-VMHostStaticIScsiTargets {
 
     $VMHosts = $null
     if ($VMHostName) {
-        $VMhosts = $Cluster| Get-VMHost -Name $VMHostName
+        $VMHosts = $Cluster| Get-VMHost -Name $VMHostName
     }
     else {
-        $VMhosts = $Cluster | Get-VMHost
+        $VMHosts = $Cluster | Get-VMHost
     }
-    if (-not $VMhosts) {
+    if (-not $VMHosts) {
         throw "No hosts found in cluster $ClusterName"
     }
 

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -767,7 +767,7 @@ function Remove-VMHostStaticIScsiTargets {
     $DatastoreDisks = Get-Datastore | Select-Object -ExpandProperty ExtensionData | Select-Object -ExpandProperty Info | Select-Object -ExpandProperty Vmfs | Select-Object -ExpandProperty Extent
     $TargetsChanged = $False
 
-    $VMhosts = $null
+    $VMHosts = $null
     if ($VMHostName) {
         $VMhosts = $Cluster| Get-VMHost -Name $VMHostName
     }
@@ -779,7 +779,7 @@ function Remove-VMHostStaticIScsiTargets {
     }
 
     # Remove iSCSI ip address from static discovery from all of hosts if there is a match
-    $HBAs =  $VMhosts | Get-VMHostHba -Type iScsi
+    $HBAs =  $VMHosts | Get-VMHostHba -Type iScsi
     foreach ($HBA in $HBAs) {
         $DeviceIds = ($HBA | Get-ScsiLun).CanonicalName
 

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -721,6 +721,9 @@ function Sync-ClusterVMHostStorage {
     .PARAMETER iSCSIAddress
      iSCSI target address. Multiple addresses can be seperated by ","
 
+    .PARAMETER VMHostName
+      Name of the VMHost (ESXi server). If not specified, all hosts in the cluster will be updated.
+
     .EXAMPLE
      Remove-VMHostStaticIScsiTargets -ClusterName "myCluster" -ISCSIAddress "192.168.1.10,192.168.1.11"
 
@@ -742,6 +745,12 @@ function Remove-VMHostStaticIScsiTargets {
         $ClusterName,
 
         [Parameter(
+                Mandatory=$false,
+                HelpMessage = 'VMHost name')]        
+        [String]
+        $VMHostName,
+
+        [Parameter(
                 Mandatory=$true,
                 HelpMessage = 'IP Address of static iSCSI target to remove. Multiple addresses can be seperated by ","')]
         [ValidateNotNull()]
@@ -755,12 +764,22 @@ function Remove-VMHostStaticIScsiTargets {
     }
 
     $iSCSIAddressList = $iSCSIAddress.Split(",")
-
     $DatastoreDisks = Get-Datastore | Select-Object -ExpandProperty ExtensionData | Select-Object -ExpandProperty Info | Select-Object -ExpandProperty Vmfs | Select-Object -ExpandProperty Extent
     $TargetsChanged = $False
 
+    $VMhosts = $null
+    if ($VMHostName) {
+        $VMhosts = $Cluster| Get-VMHost -Name $VMHostName
+    }
+    else {
+        $VMhosts = $Cluster | Get-VMHost
+    }
+    if (-not $VMhosts) {
+        throw "No hosts found in cluster $ClusterName"
+    }
+
     # Remove iSCSI ip address from static discovery from all of hosts if there is a match
-    $HBAs =  $Cluster | Get-VMHost | Get-VMHostHba -Type iScsi
+    $HBAs =  $VMhosts | Get-VMHostHba -Type iScsi
     foreach ($HBA in $HBAs) {
         $DeviceIds = ($HBA | Get-ScsiLun).CanonicalName
 
@@ -1886,6 +1905,9 @@ function Repair-HAConfiguration {
     .PARAMETER ClusterName
      vSphere Cluster Name
 
+    .PARAMETER VMHostName
+     ESXi host name. If not specified, all hosts in the cluster will be used.
+
     .EXAMPLE
      Clear-DisconnectedIscsiTargets -ClusterName "vSphere-cluster-001"
 
@@ -1900,7 +1922,12 @@ function Clear-DisconnectedIscsiTargets {
         [Parameter(
             Mandatory = $true,
             HelpMessage = 'vSphere Cluster Name')]
-        [String] $ClusterName
+        [String] $ClusterName,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'VMHost Name')]
+        [String] $VMHostName
     )
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
@@ -1910,10 +1937,18 @@ function Clear-DisconnectedIscsiTargets {
 
     $VMHosts = $null
     try {
-        $VMHosts = Get-Cluster $ClusterName | Get-VMHost
+        if ($VMHostName) {
+            $VMHosts = $Cluster | Get-VMHost -Name $VMHostName
+        } else {
+            $VMHosts = $Cluster | Get-VMHost
+        }
     }
     catch {
         throw "Failed to collect cluster hosts $($_.Exception)"
+    }
+
+    if (-not $VMHosts) {
+        throw "No matching hosts found in cluster $ClusterName"
     }
 
     foreach ($VMHost in $VMHosts) {


### PR DESCRIPTION
The changes in this PR are as follows:

* Allow specifying individual VMhost when cleaning iSCSI targets

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
Tested using on-premise deployment
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

