### PR TITLE
build fix

### DIFF
--- a/.ci/templates/common-preview-build-stages.yml
+++ b/.ci/templates/common-preview-build-stages.yml
@@ -64,7 +64,7 @@ stages:
           preview 
       displayName: Publish Preview Version
     - pwsh: |
-        echo "+ ${{ parameters.moduleFolderName }}@$(moduleVersion)" > shuttle/baseline
+        echo "+ ${{ parameters.moduleFolderName }}@$(moduleVersion)-dev" > shuttle/baseline
         dotnet shuttle/Shuttle.dll generate
       env:
         AZURE_DEVOPS_EXT_PAT: $(adoAccessToken)


### PR DESCRIPTION
Merged builds are not failing because the module is published with a suffix, while shuttle is configured w/o.
Attempting the fix, need to merge to see if it works.