### PR TITLE
Update Device ID check for restore volume function

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -574,6 +574,10 @@ function Restore-VmfsVolume {
         $DatastoreName
     )
 
+    if (!($DeviceNaaId -like 'naa.624a9370*' -or $DeviceNaaId -like 'eui.*')) {
+        throw "Invalid Device NAA ID $DeviceNaaId provided."
+    }
+
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
     if (-not $Cluster) {
         throw "Cluster $ClusterName does not exist."

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -363,7 +363,7 @@ function New-VmfsDatastore {
         Write-Error $Global:Error[0]
     }
 
-    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba | Out-Null
+    $Cluster | Get-VMHost | Get-VMHostStorage -RescanAllHba -RescanVmfs | Out-Null
     $Datastore = Get-Datastore -Name $DatastoreName -ErrorAction Ignore
     if (-not $Datastore -or $Datastore.type -ne "VMFS") {
         throw "Failed to create datastore $DatastoreName."
@@ -573,10 +573,6 @@ function Restore-VmfsVolume {
         [String]
         $DatastoreName
     )
-
-    if ($DeviceNaaId -notlike 'naa.624a9370*') {
-        throw "Invalid Device NAA ID $DeviceNaaId provided."
-    }
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
     if (-not $Cluster) {


### PR DESCRIPTION
The changes in this PR are as follows:

* Update the condition in `Restore-VmfsVolume` function to include EUI devices.
* Add missing `RescanVmfs` option in `New-VmfsDatastore`.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

