### PR TITLE
Closing Bug 29993610.  Removed VMware_Horizon from ProtectedNames

### DIFF
--- a/Microsoft.AVS.Management/AVSGenericUtils.ps1
+++ b/Microsoft.AVS.Management/AVSGenericUtils.ps1
@@ -35,7 +35,6 @@ Function Test-AVSProtectedObjectName {
         #Protected Policy Object Name Validation Check
         $ProtectedNames = @(
             "Microsoft vSAN Management Storage Policy"
-            "VMware_Horizon"
             "vSAN Default Storage Policy"
             "AVS POST IO Encryption"
             "AVS PRE IO Encryption"


### PR DESCRIPTION
This PR closes #29993610.

The changes in this PR are as follows:

* Removed VMware_Horizon entry from ProtectedNames from AVSGenericUtils.ps1 to allow customers to manage the storage policy with this name.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [N/A] **Tested the code** end-to-end against an SDDC.
* [N/A] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

