### PR TITLE
Add "Force" param to  Remove-VMHostStaticIScsiTargets

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -724,6 +724,9 @@ function Sync-ClusterVMHostStorage {
     .PARAMETER VMHostName
       Name of the VMHost (ESXi server). If not specified, all hosts in the cluster will be updated.
 
+    .PARAMETER Force
+      Force removing iSCSI target without checking if it is in use
+
     .EXAMPLE
      Remove-VMHostStaticIScsiTargets -ClusterName "myCluster" -ISCSIAddress "192.168.1.10,192.168.1.11"
 
@@ -746,7 +749,7 @@ function Remove-VMHostStaticIScsiTargets {
 
         [Parameter(
                 Mandatory=$false,
-                HelpMessage = 'VMHost name')]        
+                HelpMessage = 'VMHost name')]
         [String]
         $VMHostName,
 
@@ -755,7 +758,13 @@ function Remove-VMHostStaticIScsiTargets {
                 HelpMessage = 'IP Address of static iSCSI target to remove. Multiple addresses can be seperated by ","')]
         [ValidateNotNull()]
         [String]
-        $iSCSIAddress
+        $iSCSIAddress,
+
+        [Parameter(
+                Mandatory = $false,
+                HelpMessage = 'Force to remove iSCSI target without checking if it is in use')]
+        [bool]
+        $Force = $false                
     )
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
@@ -763,8 +772,7 @@ function Remove-VMHostStaticIScsiTargets {
         throw "Cluster $ClusterName does not exist."
     }
 
-    $iSCSIAddressList = $iSCSIAddress.Split(",")
-    $DatastoreDisks = Get-Datastore | Select-Object -ExpandProperty ExtensionData | Select-Object -ExpandProperty Info | Select-Object -ExpandProperty Vmfs | Select-Object -ExpandProperty Extent
+    $iSCSIAddressList = $iSCSIAddress.Split(",")    
     $TargetsChanged = $False
 
     $VMHosts = $null
@@ -783,15 +791,18 @@ function Remove-VMHostStaticIScsiTargets {
     foreach ($HBA in $HBAs) {
         $DeviceIds = ($HBA | Get-ScsiLun).CanonicalName
 
-        # Find if any of the devices is used as backing for a datastore
         $IsDeviceInUse = $False
-        foreach ($DeviceId in $DeviceIds) {
-            if ($DatastoreDisks.DiskName -contains $DeviceId) {
-                $IsDeviceInUse = $True
-                break
+        if (-not $Force) {
+            # Find if any of the devices is used as backing for a datastore            
+            $DatastoreDisks = (Get-Datastore).ExtensionData.Info.Vmfs.Extent
+            foreach ($DeviceId in $DeviceIds) {
+                if ($DatastoreDisks.DiskName -contains $DeviceId) {
+                    $IsDeviceInUse = $True
+                    break
+                }
             }
         }
-        if ($IsDeviceInUse) {
+        if ($IsDeviceInUse -and -not $Force) {
             Write-Warning "Datastore disk $DeviceId for host $($HBA.VMHost.Name) is in use, skipping iSCSI target removal"
         }
         else {


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* Add "Force" param to  Remove-VMHostStaticIScsiTargets that will skip cheking if the iSCSI target is in use
* ...
* ...

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [X] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
Tested using on-premise instance
* [X] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

