### PR TITLE
Fix NC Command for New-LDAPSIdentitySource

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -615,9 +615,9 @@ function New-LDAPSIdentitySource {
         catch {
             throw "The FQDN $($ResultUrl.Host) failed to do a reverse DNS lookup. $_"
         }
-        # check whether a specific port (or range of ports) on a target host is open or closed
+        # check whether a specific port (or range of ports) on a target ip address is open or closed
         try {
-            $Command = 'nc -nvz ' + $ResultUrl.Host + ' ' + $ResultUrl.Port
+            $Command = 'nc -nvz ' + $IPAddress + ' ' + $ResultUrl.Port
             $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
             if ($SSHRes.ExitStatus -ne 0) { throw "$SSHRes" }
         }


### PR DESCRIPTION
Problem: "nc -nvz" command fails if passing a hostname instead of IP address as it skips DNS lookup.

Solution: pass an IP address instead of a hostname.

Testing: 
![image](https://github.com/user-attachments/assets/e729b4a2-ca20-4f92-9464-dfc56b1fac00)


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

