### PR TITLE
[vSAN Data-In-Transit Encryption] Enabling/Disabling Commands along with Status Check

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -82,7 +82,8 @@
                    'Set-ToolsRepo', 'Set-vSANCompressDedupe', 'New-AVSStoragePolicy', 
                    'Remove-AVSStoragePolicy', 'Set-CustomDRS', 
                    'Set-AVSVSANClusterUNMAPTRIM', 'Get-AVSVSANClusterUNMAPTRIM',
-                   'Remove-CustomRole'
+                   'Remove-CustomRole',
+                   'Get-vSANDataInTransitEncryptionStatus', 'Set-vSANDataInTransitEncryption'
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
     CmdletsToExport = @()

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2674,7 +2674,8 @@ Function Get-vSANDataInTransitEncryptionStatus {
 Function Set-vSANDataInTransitEncryption {
   <#
     .DESCRIPTION
-        Enable/Disable vSAN Data-In-Transit Encryption for clusters of a SDDC
+        Enable/Disable vSAN Data-In-Transit Encryption for clusters of a SDDC.
+        There may be a performance impact when vSAN Data-In-Transit Encryption is enabled. Refer :  https://blogs.vmware.com/virtualblocks/2021/08/12/storageminute-vsan-data-encryption-performance/
     .PARAMETER ClusterName
         Name of the cluster. Leave blank if required to enable for whole SDDC else enter comma separated list of names.
     .PARAMETER Enable

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2705,9 +2705,7 @@ Function Set-vSANDataInTransitEncryption {
         }
         Else {
             $ClustersToOperateUpon = @()
-            Foreach($clusterName in $ClusterNamesArray) {
-                $ClustersToOperateUpon += (Get-Cluster -name $clusterName)
-            }
+            $ClustersToOperateUpon = $ClusterNamesArray | ForEach-Object { Get-Cluster -Name $clusterName }            
         }
         Foreach ($cluster in $ClustersToOperateUpon) {            
                 $vSANConfigView = Get-VsanView -Id VsanVcClusterConfigSystem-vsan-cluster-config-system

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2705,8 +2705,7 @@ Function Set-vSANDataInTransitEncryption {
             $ClustersToOperateUpon = Get-Cluster
         }
         Else {
-            $ClustersToOperateUpon = @()
-            $ClustersToOperateUpon = $ClusterNamesArray | ForEach-Object { Get-Cluster -Name $clusterName }            
+            $ClustersToOperateUpon = $ClusterNamesArray | ForEach-Object { Get-Cluster -Name $_ }            
         }
         Foreach ($cluster in $ClustersToOperateUpon) {            
                 $vSANConfigView = Get-VsanView -Id VsanVcClusterConfigSystem-vsan-cluster-config-system

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2672,79 +2672,80 @@ Function Get-vSANDataInTransitEncryptionStatus {
 }
 
 Function Set-vSANDataInTransitEncryption {
-    <#
-    .DESCRIPTION
-        Enable/Disable vSAN Data-In-Transit Encryption for clusters of a SDDC
-    .PARAMETER ClusterName
-        Name of the cluster. Leave blank if required to enable for whole SDDC else enter comma separated list of names.
-    .PARAMETER Enable
-        Specify True/False to Enable/Disable the feature.
-    #>
-    [CmdletBinding()]
-    [AVSAttribute(10, UpdatesSDDC = $false)]
-    param (
-        [Parameter(Mandatory = $false)]
-        [string]
-        $ClusterName,
-        [Parameter(Mandatory = $true)]
-        [bool]
-        $Enable
-    )
-    begin {
-        If ([string]::IsNullOrEmpty($ClusterName)){}
-        Else {
-            $ClusterNamesParsed = Limit-WildcardsandCodeInjectionCharacters -String $ClusterName
-            $ClusterNamesArray = Convert-StringToArray -String $ClusterNamesParsed
-        }
-        $TagName = "vSAN Data-In-Transit Encryption"        
-    }
-    process {
-        If ([string]::IsNullOrEmpty($ClusterNamesArray)) {
-            $Clusters = Get-Cluster
-            ForEach ($cluster in $Clusters) {
-                $vSANConfigView = Get-VsanView -Id VsanVcClusterConfigSystem-vsan-cluster-config-system
-                $vSANReconfigSpec = new-object -type VMware.Vsan.Views.VimVsanReconfigSpec
-                $vSANReconfigSpec.Modify = $true
-                $vSANDataInTransitConfig= new-object -type VMware.Vsan.Views.VsanDataInTransitEncryptionConfig
-                $vSANDataInTransitConfig.Enabled = $Enable
-                $vSANDataInTransitConfig.RekeyInterval = 1440
-                $vSANReconfigSpec.DataInTransitEncryptionConfig = $vSANDataInTransitConfig
-                $task = $vSANConfigView.VsanClusterReconfig($cluster.ExtensionData.MoRef,$vSANReconfigSpec)
-                Wait-Task -Task (Get-Task -Id $task)
-                If ((Get-Task -Id $task).State -eq "Success"){
-                    Add-AVSTag -Name $TagName -Description $InfoMessage -Entity $cluster
-                    Write-Host "$($cluster.Name) set to $Enable"
-                    If ($Enable) {
-                        Write-Information $InfoMessage
-                    }
-                }else {
-                    Write-Error "Failed to set $($Cluster.Name) to $Enable"
-                }
-            }
-        }
-        Else {
-            Foreach ($cluster in $ClusterNamesArray) {
-                If ($Cluster = Get-Cluster -name $cluster) {
-                    $vSANConfigView = Get-VsanView -Id VsanVcClusterConfigSystem-vsan-cluster-config-system
-                    $vSANReconfigSpec = New-Object -type VMware.Vsan.Views.VimVsanReconfigSpec
-                    $vSANReconfigSpec.Modify = $true
-                    $vSANDataInTransitConfig= New-Object -type VMware.Vsan.Views.VsanDataInTransitEncryptionConfig
-                    $vSANDataInTransitConfig.Enabled = $Enable
-                    $vSANDataInTransitConfig.RekeyInterval = 1440
-                    $vSANReconfigSpec.DataInTransitEncryptionConfig = $vSANDataInTransitConfig
-                    $task = $vSANConfigView.VsanClusterReconfig($Cluster.ExtensionData.MoRef,$vSANReconfigSpec)
-                    Wait-Task -Task (Get-Task -Id $task)
-                    If ((Get-Task -Id $task).State -eq "Success"){
-                        Add-AVSTag -Name $TagName -Description $InfoMessage -Entity $Cluster
-                        Write-Host "$($Cluster.Name) set to $Enable"
-                        If ($Enable) {
-                            Write-Information $InfoMessage
-                        }
-                    }else {
-                        Write-Error "Failed to set $($Cluster.Name) to $Enable"
-                    }
-                }
-            }
-        }
-    }
+    <#
+    .DESCRIPTION
+        Enable/Disable vSAN Data-In-Transit Encryption for clusters of a SDDC
+    .PARAMETER ClusterName
+        Name of the cluster. Leave blank if required to enable for whole SDDC else enter comma separated list of names.
+    .PARAMETER Enable
+        Specify True/False to Enable/Disable the feature.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ClusterName,
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $Enable
+    )
+    begin {
+        If ([string]::IsNullOrEmpty($ClusterName)){}
+        Else {
+            $ClusterNamesParsed = Limit-WildcardsandCodeInjectionCharacters -String $ClusterName
+            $ClusterNamesArray = Convert-StringToArray -String $ClusterNamesParsed
+        }
+        Write-Host "Enable value is $Enable"
+        $TagName = "vSAN Data-In-Transit Encryption"  
+        $InfoMessage = "Info - There may be a performance impact when vSAN Data-In-Transit Encryption is enabled. Refer :  https://blogs.vmware.com/virtualblocks/2021/08/12/storageminute-vsan-data-encryption-performance/"      
+    }
+    process {
+        If ([string]::IsNullOrEmpty($ClusterNamesArray)) {
+            $Clusters = Get-Cluster
+            ForEach ($cluster in $Clusters) {
+                $vSANConfigView = Get-VsanView -Id VsanVcClusterConfigSystem-vsan-cluster-config-system
+                $vSANReconfigSpec = new-object -type VMware.Vsan.Views.VimVsanReconfigSpec
+                $vSANReconfigSpec.Modify = $true
+                $vSANDataInTransitConfig= new-object -type VMware.Vsan.Views.VsanDataInTransitEncryptionConfig
+                $vSANDataInTransitConfig.Enabled = $Enable
+                $vSANDataInTransitConfig.RekeyInterval = 1440
+                $vSANReconfigSpec.DataInTransitEncryptionConfig = $vSANDataInTransitConfig
+                $task = $vSANConfigView.VsanClusterReconfig($cluster.ExtensionData.MoRef,$vSANReconfigSpec)
+                Wait-Task -Task (Get-Task -Id $task)
+                If ((Get-Task -Id $task).State -eq "Success"){
+                    Add-AVSTag -Name $TagName -Description $InfoMessage -Entity $Cluster                  
+                    Write-Host "$($cluster.Name) set to $Enable"
+                    If ($Enable) {
+                        Write-Information $InfoMessage
+                    }
+                }else {
+                    Write-Error "Failed to set $($Cluster.Name) to $Enable"
+                }
+            }
+        }
+        Else {
+            Foreach ($cluster in $ClusterNamesArray) {
+                If ($Cluster = Get-Cluster -name $cluster) {
+                    $vSANConfigView = Get-VsanView -Id VsanVcClusterConfigSystem-vsan-cluster-config-system
+                    $vSANReconfigSpec = New-Object -type VMware.Vsan.Views.VimVsanReconfigSpec
+                    $vSANReconfigSpec.Modify = $true
+                    $vSANDataInTransitConfig= New-Object -type VMware.Vsan.Views.VsanDataInTransitEncryptionConfig
+                    $vSANDataInTransitConfig.Enabled = $Enable
+                    $vSANDataInTransitConfig.RekeyInterval = 1440
+                    $vSANReconfigSpec.DataInTransitEncryptionConfig = $vSANDataInTransitConfig
+                    $task = $vSANConfigView.VsanClusterReconfig($Cluster.ExtensionData.MoRef,$vSANReconfigSpec)
+                    Wait-Task -Task (Get-Task -Id $task)
+                    If ((Get-Task -Id $task).State -eq "Success"){ 
+                        Add-AVSTag -Name $TagName -Description $InfoMessage -Entity $Cluster                    
+                        Write-Host "$($Cluster.Name) set to $Enable"
+                        If ($Enable) {
+                            Write-Information $InfoMessage
+                        }
+                    }else {
+                        Write-Error "Failed to set $($Cluster.Name) to $Enable"
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2680,6 +2680,7 @@ Function Set-vSANDataInTransitEncryption {
     .PARAMETER Enable
         Specify True/False to Enable/Disable the feature.
     #>
+    [AVSAttribute(10, UpdatesSDDC = $false)]
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $false)]


### PR DESCRIPTION
This PR creates new RUN Commands to set vsan-data-in-transit-encryption for Cx SDDC Clusters

The changes in this PR are as follows:

*  Enable/Disable the feature
*  Get current status of feature per cluster or sddc

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

Tested the functionality for both enabling and disabling the feature.

![image](https://github.com/user-attachments/assets/f8e419c0-30cb-45b4-b04d-8925a60f4e66)

![image](https://github.com/user-attachments/assets/3439cc2c-1fce-4063-9933-404a476126bc)


