### PR TITLE
Fix SSH Result Output

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -598,7 +598,7 @@ function New-LDAPSIdentitySource {
         try {
             $Command = 'nslookup ' + $ResultUrl.Host + ' -type=soa'
             $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
-            if ($SSHRes.ExitStatus -ne 0) { throw "$SSHRes" }
+            if ($SSHRes.ExitStatus -ne 0) { throw "$($SSHRes.Output)" }
             $IPAddress = $SSHRes.Output | Select-String "Address:" | Where-Object { $_ -notmatch "#" } | ForEach-Object { $_.ToString().Split()[1] } | Select-Object -First 1
             if (-Not ($IPAddress -as [ipaddress])) { throw "The FQDN $($ResultUrl.Host) failed to resolved to an IP address or incorrect IP format. Make sure DNS is configured correctly." }
         }
@@ -610,7 +610,7 @@ function New-LDAPSIdentitySource {
         try {
             $Command = 'nslookup ' + $IPAddress
             $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
-            if ($SSHRes.ExitStatus -ne 0) { throw "The FQDN $($ResultUrl.Host) is resolved successfully but the IP address $($IPAddress) does not have a corresponding DNS PTR (pointer) record, which is used for reverse DNS lookups. Make sure DNS is configured. $SSHRes" }
+            if ($SSHRes.ExitStatus -ne 0) { throw "The FQDN $($ResultUrl.Host) is resolved successfully but the IP address $($IPAddress) does not have a corresponding DNS PTR (pointer) record, which is used for reverse DNS lookups. Make sure DNS is configured. $($SSHRes.Output)" }
         }
         catch {
             throw "The FQDN $($ResultUrl.Host) failed to do a reverse DNS lookup. $_"
@@ -619,7 +619,7 @@ function New-LDAPSIdentitySource {
         try {
             $Command = 'nc -nvz ' + $IPAddress + ' ' + $ResultUrl.Port
             $SSHRes = Invoke-SSHCommand -Command $Command -SSHSession $SSH_Sessions['VC'].Value
-            if ($SSHRes.ExitStatus -ne 0) { throw "$SSHRes" }
+            if ($SSHRes.ExitStatus -ne 0) { throw "$($SSHRes.Output)" }
         }
         catch {
             throw "The connection cannot be established. Please check the address, routing and/or firewall and make sure port $($ResultUrl.Port) is open. $_"


### PR DESCRIPTION
This PR closes #

The changes in this PR are as follows:

* when SSH fails, it stores error messages in $SSHRes.Output. Printing $SSHRes.Output give a better understanding of the error.


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

