### PR TITLE
Update Microsoft.AVS.Management.psm1

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -626,7 +626,9 @@ function New-LDAPSIdentitySource {
             if ($SSHRes.ExitStatus -ne 0) { throw "The FQDN $($ResultUrl.Host) is resolved successfully but the IP address $($IPAddress) does not have a corresponding DNS PTR (pointer) record, which is used for reverse DNS lookups. Make sure DNS is configured. $($SSHRes.Output)" }
         }
         catch {
-            throw "The FQDN $($ResultUrl.Host) failed to do a reverse DNS lookup. $_"
+            Write-Warning "The FQDN $($ResultUrl.Host) failed to do a reverse DNS lookup. $_"
+	    Write-Warning "For reverse lookup to work, DEFAULT zone in NSX-T DNS forwarder must be set to query a DNS server that can resolve reverse DNS lookup of $($ResultUrl.Host)"
+            Write-Warning "Reverse lookup may not be required for LDAPS configuration."
         }
         # check whether a specific port (or range of ports) on a target ip address is open or closed
         try {


### PR DESCRIPTION
Changing check to warn, not fail.

This PR closes #298 

The changes in this PR are as follows:

* Changes reverse DNS check to not be a terminal failure.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

