### PR TITLE
Fix New-LDAPS Regression

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -299,6 +299,9 @@ function Get-CertificateFromServerToLocalFile {
     $DestinationFileArray = @()
     $exportFolder = $pwd.Path + "/"
     foreach ($computerUrl in $remoteComputers) {
+        $ParsedUrl = [System.Uri]$computerUrl
+        $ResultUrlString = $ParsedUrl.GetLeftPart([UriPartial]::Authority)
+        $ResultUrl = [System.Uri]$ResultUrlString
         try {
             Write-Host ("Starting to Download Cert from " + $computerUrl)
             $Command = 'echo "1" | openssl s_client -connect ' + $ResultUrl.Host + ':' + $ResultUrl.Port + ' -showcerts'


### PR DESCRIPTION
This PR closes #
New-LDAPS command introduced a regression: missing variables skipped the second certificates download when secondaryUrl of DC was provided.

The changes in this PR are as follows:

* Initialize variables for each computerURL.
* Test:
![image](https://github.com/user-attachments/assets/d20cc019-88a2-4272-affe-803d46f415f2)

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

