### PR TITLE
install fixed psresourceget

### DIFF
--- a/.build-tools/getRequiredModules.ps1
+++ b/.build-tools/getRequiredModules.ps1
@@ -4,6 +4,9 @@ param (
     [Parameter(Mandatory=$true)][string]$psdPath
 )
 $c =  [PSCredential]::new("ado", ($accessToken | ConvertTo-SecureString -AsPlainText -Force))
+# https://github.com/PowerShell/PSResourceGet/issues/1777
+Install-Module Microsoft.PowerShell.PSResourceGet -requiredversion 1.1.1 -Repository Consumption -Credential $c -Force -SkipPublisherCheck
+
 $requiredModules = (Test-ModuleManifest "$psdPath" -ErrorAction SilentlyContinue).RequiredModules
 foreach ($module in $requiredModules) {
     $targetModule = $($module.Name)


### PR DESCRIPTION
This PR addresses the [bug in PSResourceGet](https://github.com/PowerShell/PSResourceGet/issues/1777) that results in incorrect version spec for dependencies.

