### PR TITLE
Use install-less shuttle to generate metadata

### DIFF
--- a/.ci/vars.yml
+++ b/.ci/vars.yml
@@ -16,7 +16,7 @@ variables:
   vvolsStageForSigningFolder: 'forSigningVvols'
   nfsStageForUnsignedFolder: 'unsignedNfs'
   nfsStageForSigningFolder: 'forSigningNfs'
-  shuttleVersion: '1.0.97-91b78925'
+  shuttleVersion: '1.0.107-00ce444a'
   metadataAuthority: 'https://msazure.visualstudio.com'
   metadataProject: 'One'
   metadataFeed: 'avs-scripting-metadata'


### PR DESCRIPTION
This PR follows up on the s360 item to use auth mirror for installing the packages.