### PR TITLE
Removed 'foreground' option from write-information

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1504,7 +1504,7 @@ function Set-ToolsRepo {
             Write-Information "Skipping copy of $tools_version to $ds_name as there is a newer version already present" -InformationAction Continue
         }
         else {
-            Write-Information "Copying $tools_version to $ds_name" -ForegroundColor Green
+            Write-Information "Copying $tools_version to $ds_name"
             Copy-DatastoreItem -Item "./${tools_version}/*" "DS:/$new_folder" -Recurse -Force
         }
 


### PR DESCRIPTION
Option doesn't exist on "Information"

This PR closes # [32324636](https://msazure.visualstudio.com/One/_workitems/edit/32324636)

The changes in this PR are as follows:

* Remove the 'Foreground' option
