### PR TITLE
Update Microsoft.AVS.VMFS.psm1

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -608,9 +608,21 @@ function Restore-VmfsVolume {
         $DatastoreName
     )
 
+    <#
+    proposed change to allow Netapp NAA ID for Restore-Vmfsvolume
     if (!($DeviceNaaId -like 'naa.624a9370*' -or $DeviceNaaId -like 'eui.*')) {
         throw "Invalid Device NAA ID $DeviceNaaId provided."
     }
+    #>
+
+if (!(
+    $DeviceNaaId -like 'naa.624a9370*' -or # Pure Storage
+    $DeviceNaaId -like 'eui.*' -or         # NVMe/TCP
+    $DeviceNaaId -like 'naa.600a098*'      # NetApp - new change
+)) {
+    throw "Invalid Device NAA ID $DeviceNaaId provided. Only Pure Storage (naa.624a9370), NetApp (naa.600a098), or NVMe/TCP (eui.*) are supported."
+}
+
 
     $Cluster = Get-Cluster -Name $ClusterName -ErrorAction Ignore
     if (-not $Cluster) {


### PR DESCRIPTION
Added NAA id to Restore-Vmfasvolume to allow Netapp. From line 611.

if (!(
    $DeviceNaaId -like 'naa.624a9370*' -or # Pure Storage
    $DeviceNaaId -like 'eui.*' -or         # NVMe/TCP
    $DeviceNaaId -like 'naa.600a098*'      # NetApp
)) {
    throw "Invalid Device NAA ID $DeviceNaaId provided. Only Pure Storage (naa.624a9370), NetApp (naa.600a098), or NVMe/TCP (eui.*) are supported."
}

This PR closes #

The changes in this PR are as follows:

* ...
* ...
* ...

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

