### PR TITLE
Check if VMFS volume can be expanded

### DIFF
--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -538,7 +538,7 @@ function Resize-VmfsVolume {
     }
 
     if (-not $DatastoreToResize) {
-        throw "Failed to re-size VMFS volume."
+        throw "Failed to re-size VMFS volume, datastore not found."
     }
 
     $NaaId = $DatastoreToResize.ExtensionData.Info.Vmfs.Extent.DiskName
@@ -556,6 +556,10 @@ function Resize-VmfsVolume {
     $Esxi = Get-View -Id ($DatastoreToResize.ExtensionData.Host | Select-Object -last 1 | Select-Object -ExpandProperty Key)
     $DatastoreSystem = Get-View -Id $Esxi.ConfigManager.DatastoreSystem
     $ExpandOptions = $DatastoreSystem.QueryVmfsDatastoreExpandOptions($DatastoreToResize.ExtensionData.MoRef)
+
+    if ($ExpandOptions.Count -eq 0) {
+        throw "Unable to expand VMFS datastore $($DatastoreToResize.Name)."
+    }
 
     Write-Host "Increasing the size of the VMFS volume..."
     $DatastoreSystem.ExpandVmfsDatastore($DatastoreToResize.ExtensionData.MoRef, $ExpandOptions[0].spec)

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -557,7 +557,7 @@ function Resize-VmfsVolume {
     $DatastoreSystem = Get-View -Id $Esxi.ConfigManager.DatastoreSystem
     $ExpandOptions = $DatastoreSystem.QueryVmfsDatastoreExpandOptions($DatastoreToResize.ExtensionData.MoRef)
 
-    $LunSizeGB = ($DatastoreToResize | Get-ScsiLun).CapacityGB
+    $LunSizeGB = ($DatastoreToResize | Get-ScsiLun).CapacityGB | Select-Object -last 1
     $CurrentDatastoreSizeGB = $([math]::Ceiling($DatastoreToResize.ExtensionData.Info.Vmfs.Capacity / 1GB))
     if ($CurrentDatastoreSizeGB -lt $LunSizeGB) {
         Write-Host "Increasing the size of the VMFS volume..."


### PR DESCRIPTION
The changes in this PR are as follows:

* Add additional logs to `Resize-VmfsVolume` related to datastore size before and after expanding.
* Better error handling in `Resize-VmfsVolume` if the datastore is not found or if the volume cannot be expanded.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

