### PR TITLE
Fix NetCat test issue in Debug-LDAPSIdentitySources

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -395,7 +395,6 @@ function Debug-LDAPSIdentitySources {
 
                     # Now let's look at the port numbers
                     if($ldap_portspec -ne "") {
-                        $ldap_port = $ldap_portspec -match ":([0-9]+)"
                         Write-Host "  LDAP Port number:      $ldap_port"
                     } else {
                         switch($ldap_protocol) {


### PR DESCRIPTION
This PR addresses issues described in Issue #334 by removing unnecessary line of code, which in turn causes issues during NetCat tests.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

