### PR TITLE
VMFS kernel adapter validation

### DIFF
--- a/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psd1
+++ b/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psd1
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "7.0.175" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "7.0.198" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "7.0.175" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "7.0.198" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psm1
@@ -84,6 +84,27 @@ function Set-VmfsIscsi {
 
     $VMHosts = $Cluster | Get-VMHost
     foreach ($VMHost in $VMHosts) {
+        # vmk5 and vmk6 are not provisioned for Microsoft hosts
+        if ($VMHost.ExtensionData.Hardware.SystemInfo.Vendor -eq "Microsoft Corporation") {
+            continue;
+        }
+
+        try {
+            $KernelAdapters = Get-VMHostNetworkAdapter -VMHost $VmHost.Name -VMKernel
+        }
+        catch {
+            throw "Failed to collect VMKernel info on host $($VmHost.Name), unable to verify whether vmk5 and vmk6 exist."
+        }
+
+        
+        $vmk5 = $KernelAdapters | Where-Object { $_.Name -eq "vmk5" }
+        $vmk6 = $KernelAdapters | Where-Object { $_.Name -eq "vmk6" }
+        if ((-not $vmk5) -or (-not $vmk6)) {
+            throw "Kernel Adapters vmk5 and vmk6 do not exist on host $($VmHost.Name)."
+        }
+    }
+
+    foreach ($VMHost in $VMHosts) {
         $Iscsi = $VMHost | Get-VMHostStorage
         if ($Iscsi.SoftwareIScsiEnabled -ne $true) {
             $VMHost | Get-VMHostStorage | Set-VMHostStorage -SoftwareIScsiEnabled $True | Out-Null
@@ -212,6 +233,27 @@ function Set-VmfsStaticIscsi {
     }
 
     $VMHosts = $Cluster | Get-VMHost
+    foreach ($VMHost in $VMHosts) {
+        # vmk5 and vmk6 are not provisioned for Microsoft hosts
+        if ($VMHost.ExtensionData.Hardware.SystemInfo.Vendor -eq "Microsoft Corporation") {
+            continue;
+        }
+
+        try {
+            $KernelAdapters = Get-VMHostNetworkAdapter -VMHost $VmHost.Name -VMKernel
+        }
+        catch {
+            throw "Failed to collect VMKernel info on host $($VmHost.Name), unable to verify whether vmk5 and vmk6 exist."
+        }
+
+        
+        $vmk5 = $KernelAdapters | Where-Object { $_.Name -eq "vmk5" }
+        $vmk6 = $KernelAdapters | Where-Object { $_.Name -eq "vmk6" }
+        if ((-not $vmk5) -or (-not $vmk6)) {
+            throw "Kernel Adapters vmk5 and vmk6 do not exist on host $($VmHost.Name)."
+        }
+    }
+
     foreach ($VMHost in $VMHosts) {
         $Iscsi = $VMHost | Get-VMHostStorage
         if ($Iscsi.SoftwareIScsiEnabled -ne $true) {

--- a/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
+++ b/Microsoft.AVS.VVOLS/Microsoft.AVS.VVOLS.psd1
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules   = @(
-        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "7.0.175" }
+        @{ "ModuleName" = "Microsoft.AVS.Management"; "ModuleVersion" = "7.0.198" }
     )
 
     # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
The changes in this PR are as follows:

* Check whether vmk5 and vmk6 are provisioned prior to iSCSI configuration.
* Update `Microsoft.AVS.Management` dependency version to `7.0.198`.

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

