### PR TITLE
Copilot/fix avs storage policy issue for RAID-6 FTT-2

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2414,11 +2414,11 @@ Function New-AVSStoragePolicy {
                 $Subprofile = new-object VMware.Spbm.Views.PbmCapabilityInstance
                 $Subprofile.Id = New-Object VMware.Spbm.Views.PbmCapabilityMetadataUniqueId
                 $Subprofile.Id.Namespace = "VSAN"
-                $Subprofile.Id.Id = "hostFailuresToTolerate"
+                $Subprofile.Id.Id = "replicaPreference"
                 $Subprofile.Constraint = New-Object VMware.Spbm.Views.PbmCapabilityConstraintInstance
                 $Subprofile.Constraint[0].PropertyInstance = New-Object VMware.Spbm.Views.PbmCapabilityPropertyInstance
                 $Subprofile.Constraint[0].PropertyInstance[0].id = $Subprofile.Id.Id
-                $Subprofile.Constraint[0].PropertyInstance[0].value = 2
+                $Subprofile.Constraint[0].PropertyInstance[0].value = "RAID-5/6 (Erasure Coding) - Capacity"
                 If (($profilespec.Constraints.SubProfiles | Where-Object { $_.Name -eq "VSAN" }).count -eq 0) {
                     $profilespec.Constraints.SubProfiles += new-object VMware.Spbm.Views.PbmCapabilitySubProfile -Property @{"Name" = "VSAN" }
                     Write-Information "Added VSAN Subprofile to ProfileSpec"
@@ -2429,11 +2429,11 @@ Function New-AVSStoragePolicy {
                 $Subprofile = new-object VMware.Spbm.Views.PbmCapabilityInstance
                 $Subprofile.Id = New-Object VMware.Spbm.Views.PbmCapabilityMetadataUniqueId
                 $Subprofile.Id.Namespace = "VSAN"
-                $Subprofile.Id.Id = "replicaPreference"
+                $Subprofile.Id.Id = "hostFailuresToTolerate"
                 $Subprofile.Constraint = New-Object VMware.Spbm.Views.PbmCapabilityConstraintInstance
                 $Subprofile.Constraint[0].PropertyInstance = New-Object VMware.Spbm.Views.PbmCapabilityPropertyInstance
                 $Subprofile.Constraint[0].PropertyInstance[0].id = $Subprofile.Id.Id
-                $Subprofile.Constraint[0].PropertyInstance[0].value = "RAID-5/6 (Erasure Coding) - Capacity"
+                $Subprofile.Constraint[0].PropertyInstance[0].value = 2
                 ($profilespec.Constraints.SubProfiles | Where-Object { $_.Name -eq "VSAN" }).Capability += $subprofile
 
                 $Subprofile = new-object VMware.Spbm.Views.PbmCapabilityInstance


### PR DESCRIPTION
This PR closes #
[Bug 35550517](https://msazure.visualstudio.com/One/_workitems/edit/35550517): Using Run Command to create RAID-6 policy with FTT-2 actually creates a RAID-5 policy

The changes in this PR are as follows:

* Changes the order the parameters are passed in the RAID-6 section

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

