### PR TITLE
Have Test-AVSProtectedObjectName exit on match

### DIFF
--- a/Microsoft.AVS.Management/AVSGenericUtils.ps1
+++ b/Microsoft.AVS.Management/AVSGenericUtils.ps1
@@ -254,8 +254,7 @@ function Test-AVSProtectedObjectName {
         # Check if the name is in the protected names list
         # If it is a protected name 'throw' and don't continue
         if ($ProtectedNames -contains $Name) {
-            Write-Error "$Name is a protected name.  Please use a different name."
-            throw
+            throw "$Name is a protected name.  Please use a different name."
         }
         # If not a protected name, return false
         Write-Information "$Name is not a protected name."

--- a/Microsoft.AVS.Management/AVSGenericUtils.ps1
+++ b/Microsoft.AVS.Management/AVSGenericUtils.ps1
@@ -258,7 +258,7 @@ function Test-AVSProtectedObjectName {
             throw
         }
         # If not a protected name, return false
-        Write-Host -ForegroundColor Green "$Name is not a protected name."
+        Write-Information "$Name is not a protected name."
         return $false
     }
 }

--- a/Microsoft.AVS.Management/AVSGenericUtils.ps1
+++ b/Microsoft.AVS.Management/AVSGenericUtils.ps1
@@ -156,10 +156,7 @@ function Get-MgmtResourcePoolVMs {
     return [pscustomobject]@{ Names=@($names); MoRefs=@($mors); Count=$names.Count }
 }
 
-
-
-
-Function Test-AVSProtectedObjectName {
+function Test-AVSProtectedObjectName {
     <#
     .DESCRIPTION
         This function tests if an object name is valid.
@@ -176,7 +173,7 @@ Function Test-AVSProtectedObjectName {
         [string]
         $Name
     )
-    Begin {
+    begin {
         #Protected Policy Object Name Validation Check
         $ProtectedNames = @(
             "Microsoft vSAN Management Storage Policy"
@@ -250,19 +247,19 @@ Function Test-AVSProtectedObjectName {
             "CloudAdmin"
             "HmsRemoteUser"
             "NsxAuditor"
-            )
+        )
         $Name = Limit-WildcardsandCodeInjectionCharacters -String $Name
     }
-    Process {
-        ForEach ($ProtectedName in $ProtectedNames) {
-            if ($ProtectedName -eq $Name) {
-                Write-Error "$ProtectedName is a protected name.  Please use a different name."
-                Return $true
-                return
-            }
+    process {
+        # Check if the name is in the protected names list
+        # If it is a protected name 'throw' and don't continue
+        if ($ProtectedNames -contains $Name) {
+            Write-Error "$Name is a protected name.  Please use a different name."
+            throw
         }
+        # If not a protected name, return false
         Write-Host -ForegroundColor Green "$Name is not a protected name."
-        Return $false
+        return $false
     }
 }
 

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -906,11 +906,9 @@ function Remove-AVSStoragePolicy {
     # It will throw an error if the name is protected
     Test-AVSProtectedObjectName -Name $Name
 
-    try {
-        $StoragePolicy = Get-SpbmStoragePolicy -Name $Name -ErrorAction Stop
-    } catch {
-        Write-Information "Storage Policy $Name does not exist."
-        return
+    $StoragePolicy = Get-SpbmStoragePolicy -Name $Name -ErrorAction SilentlyContinue
+    if (-not $StoragePolicy) {
+        throw "Storage Policy $Name does not exist."
     }
 
     #Remove Storage Policy
@@ -918,16 +916,15 @@ function Remove-AVSStoragePolicy {
         Remove-SpbmStoragePolicy -StoragePolicy $StoragePolicy -Confirm:$false -ErrorAction Stop
         Write-Information "Storage Policy $Name removed successfully."
     } catch {
-        Write-Error "Failed to remove Storage Policy $Name. $_"
-        return
+        throw "Failed to remove Storage Policy $Name. $_"
     }
 
     #Validate Storage Policy was removed
-    try {
-        $StoragePolicy = Get-SpbmStoragePolicy -Name $Name -ErrorAction Stop
-        Write-Error "Storage Policy $Name still exists after removal."
-    } catch {
-        Write-Information "Validated: Storage Policy $Name no longer exists."
+    $StoragePolicy = Get-SpbmStoragePolicy -Name $Name -ErrorAction SilentlyContinue
+    if (-not $StoragePolicy) {
+         "Storage Policy $Name removed successfully and validated."
+    } else {
+        throw "Storage Policy $Name still exists -- removal failed."
     }
 }
 


### PR DESCRIPTION
This PR closes # [Bug 36518718: Run Command can delete a built-in vSAN Storage policy](https://msazure.visualstudio.com/One/_workitems/edit/36518718)

The changes in this PR are as follows:

* Removes 'foreach' loop for an 'array contains'
* Issues a 'throw' if there is a match instead of returning to the calling function (safer than returning)

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

