### PR TITLE
EsxTopcommand

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -91,6 +91,7 @@
         'Get-UnassociatedvSANObjectsWithPolicy'
         'Update-StoragePolicyofUnassociatedvSANObjects'
         'Remove-AvsUnassociatedObject'
+        'Get-EsxtopData'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1971,11 +1971,7 @@ function Get-EsxtopData {
 
     $cluster = Get-Cluster -Name $ClusterName -ErrorAction Stop
     $vmHost = $cluster | Get-VMHost |
-        Where-Object {
-            $_.Name -like "$EsxiHostName*" -and
-            $_.ConnectionState -eq 'Connected' -and
-            $_.ExtensionData.Hardware.SystemInfo.Vendor -inotlike "Microsoft*"
-        } |
+        Where-Object { $_.Name -like "$EsxiHostName*" -and $_.ConnectionState -eq 'Connected' } |
         Select-Object -First 1
 
     if ($null -eq $vmHost) {

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1881,3 +1881,219 @@ Function Set-vSANDataInTransitEncryption {
 
         }
 }
+
+function Get-EsxtopData {
+    <#
+    .SYNOPSIS
+        Collects esxtop performance data from an ESXi host via the vCenter Esxtop service API.
+
+    .DESCRIPTION
+        Collects batch-mode esxtop snapshots from a single ESXi host via the vCenter ServiceManager
+        API (no SSH) and uploads the resulting CSV to the cluster's vSAN datastore (or a
+        customer-specified datastore via OutputDatastoreName).
+
+    .PARAMETER ClusterName
+        The name of the vSphere cluster containing the target ESXi host.
+
+    .PARAMETER EsxiHostName
+        The ESXi host name or prefix. The first connected host matching this prefix is used.
+
+    .PARAMETER Iterations
+        Number of FetchStats snapshots. Combined with IntervalSeconds, total spacing between the
+        first and last sample must not exceed 30 seconds: (Iterations - 1) * IntervalSeconds <= 30.
+
+    .PARAMETER IntervalSeconds
+        Seconds to wait after each sample before the next (not applied after the last sample).
+        Range 2-30. The minimum of 2 seconds aligns with esxtop's minimum sampling interval.
+
+    .PARAMETER OutputDatastoreName
+        Name of the datastore to upload the CSV to. When omitted, defaults to the first vSAN
+        datastore on the cluster. Specify this to use a non-vSAN datastore or when automatic
+        vSAN discovery does not find the desired target.
+
+    .NOTES
+        Get-View emits a non-fatal "Invalid property" error for ServiceManager and Esxtop service
+        objects but still returns a usable object. ErrorAction SilentlyContinue suppresses the noise.
+        The returned object is validated via Get-Member before use.
+
+        The Esxtop SimpleCommand API (CounterInfo, FetchStats, FreeStats) is not covered in the
+        official vSphere API reference. The approach used here is based on:
+        - https://williamlam.com/2017/02/using-the-vsphere-api-in-vcenter-server-to-collect-esxtop-vscsistats-metrics.html
+        - https://github.com/lamw/vmware-scripts/blob/master/powershell/Get-EsxtopAPI.ps1
+    #>
+
+    [CmdletBinding()]
+    [AVSAttribute(30, UpdatesSDDC = $false)]
+    param(
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'Name of the vSphere cluster containing the target ESXi host.')]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClusterName,
+
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'ESXi host name or name prefix. The first matching host will be used.')]
+        [ValidateNotNullOrEmpty()]
+        [string]$EsxiHostName,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'Number of FetchStats snapshots (spacing (Iterations-1)*IntervalSeconds must be <= 30s).')]
+        [ValidateRange(1, 6)]
+        [int]$Iterations = 6,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'Seconds between snapshots (2-30; with Iterations, total spacing <= 30s).')]
+        [ValidateRange(2, 30)]
+        [int]$IntervalSeconds = 5,
+
+        [Parameter(
+            Mandatory = $false,
+            HelpMessage = 'Name of the datastore for CSV upload. Defaults to the first vSAN datastore on the cluster.')]
+        [ValidateNotNullOrEmpty()]
+        [string]$OutputDatastoreName
+    )
+
+    $EsxiHostName = Limit-WildcardsandCodeInjectionCharacters -String $EsxiHostName
+    $ClusterName = Limit-WildcardsandCodeInjectionCharacters -String $ClusterName
+    if ($PSBoundParameters.ContainsKey('OutputDatastoreName')) {
+        $OutputDatastoreName = Limit-WildcardsandCodeInjectionCharacters -String $OutputDatastoreName
+    }
+
+    $samplingSpanSec = [Math]::Max(0, $Iterations - 1) * $IntervalSeconds
+    if ($samplingSpanSec -gt 30) {
+        throw ("Esxtop sampling is limited to 30 seconds between the first and last sample: " +
+            "(Iterations-1)*IntervalSeconds must be <= 30. Current spacing is ${samplingSpanSec}s " +
+            "(Iterations=$Iterations, IntervalSeconds=$IntervalSeconds).")
+    }
+
+    $cluster = Get-Cluster -Name $ClusterName -ErrorAction Stop
+    $vmHost = $cluster | Get-VMHost |
+        Where-Object { $_.Name -like "$EsxiHostName*" -and $_.ConnectionState -eq 'Connected' } |
+        Select-Object -First 1
+
+    if ($null -eq $vmHost) {
+        throw "No connected ESXi host matching '$EsxiHostName' found in cluster '$ClusterName'."
+    }
+
+    Write-Host "Target host: $($vmHost.Name)"
+
+    # Get ServiceManager via Get-View (emits non-fatal error but returns usable object)
+    $serviceManager = Get-View ($global:DefaultVIServer.ExtensionData.Content.ServiceManager) -Property "" -ErrorAction SilentlyContinue
+    if ($null -eq $serviceManager) {
+        throw "Could not resolve ServiceManager via Get-View."
+    }
+    if (-not (Get-Member -InputObject $serviceManager -Name "QueryServiceList")) {
+        throw "ServiceManager object is missing QueryServiceList method. MoRef may be invalid."
+    }
+
+    # Query services on the target host
+    $locationString = "vmware.host." + $vmHost.Name
+    $services = $serviceManager.QueryServiceList($null, $locationString)
+    if (-not $services) {
+        throw "No services found at location '$locationString'."
+    }
+
+    $esxtopService = $null
+    foreach ($svc in $services) {
+        if ($svc.ServiceName -eq "Esxtop") {
+            $esxtopService = $svc
+            break
+        }
+    }
+    if ($null -eq $esxtopService) {
+        $available = ($services | ForEach-Object { $_.ServiceName }) -join ', '
+        throw "Esxtop service not found on host $($vmHost.Name). Available: $available"
+    }
+
+    $esxtopView = Get-View $esxtopService.Service -Property "" -ErrorAction SilentlyContinue
+    if ($null -eq $esxtopView) {
+        throw "Could not resolve Esxtop service view via Get-View."
+    }
+    if (-not (Get-Member -InputObject $esxtopView -Name "ExecuteSimpleCommand")) {
+        throw "Esxtop service view is missing ExecuteSimpleCommand method. MoRef may be invalid."
+    }
+
+    # CounterInfo
+    $counterInfo = $esxtopView.ExecuteSimpleCommand("CounterInfo")
+
+    # FetchStats loop — collect samples to local temp file, then upload to vSAN datastore
+    $hostShort = $vmHost.Name.Split('.')[0]
+    $runTimestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $csvFileName = "esxtop_${hostShort}_${runTimestamp}.csv"
+    $tempCsv = Join-Path ([System.IO.Path]::GetTempPath()) $csvFileName
+
+    Write-Host "Collecting $Iterations samples from $($vmHost.Name) (interval=${IntervalSeconds}s)..."
+    '"Timestamp","SampleNumber","RawData"' | Out-File -FilePath $tempCsv -Encoding UTF8
+    $totalBytes = 0
+
+    for ($i = 1; $i -le $Iterations; $i++) {
+        $stats = $esxtopView.ExecuteSimpleCommand("FetchStats")
+
+        $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        $escaped = $stats -replace '"', '""'
+        $csvRow = '"' + $timestamp + '",' + $i + ',"' + $escaped + '"'
+        $csvRow | Out-File -FilePath $tempCsv -Encoding UTF8 -Append
+        $totalBytes += $stats.Length
+
+        $pct = [math]::Round(($i / $Iterations) * 100)
+        $dataKB = [math]::Round($totalBytes / 1024, 1)
+        Write-Host "Sample $i/$Iterations (${pct}%) - ${dataKB} KB collected"
+
+        if ($i -lt $Iterations) {
+            Start-Sleep -Seconds $IntervalSeconds
+        }
+    }
+
+    # FreeStats
+    try {
+        $esxtopView.ExecuteSimpleCommand("FreeStats") | Out-Null
+    }
+    catch {
+        Write-Warning "FreeStats call failed: $($_.Exception.Message)"
+    }
+
+    # Upload CSV to datastore
+    try {
+        if ($PSBoundParameters.ContainsKey('OutputDatastoreName')) {
+            $datastore = Get-Datastore -Name $OutputDatastoreName -ErrorAction Stop
+        }
+        else {
+            $datastore = Get-Datastore -RelatedObject $cluster -ErrorAction SilentlyContinue |
+                Where-Object { $_.Type -eq 'vsan' -or $_.Name -like '*vsan*' -or $_.Name -like '*vsanDatastore*' } |
+                Select-Object -First 1
+        }
+
+        if ($null -eq $datastore) {
+            Write-Warning ("No vSAN datastore found on cluster '$ClusterName'. CSV saved locally at $tempCsv. " +
+                "Use -OutputDatastoreName to specify an accessible datastore.")
+        }
+        else {
+            $driveName = "esxtopUpload"
+            if (Get-PSDrive -Name $driveName -ErrorAction SilentlyContinue) {
+                Remove-PSDrive -Name $driveName -Force -ErrorAction SilentlyContinue
+            }
+            New-PSDrive -Name $driveName -Location $datastore -PSProvider VimDatastore -Root "\" -ErrorAction Stop | Out-Null
+
+            $destFolder = "${driveName}:\esxtop_output"
+            if (-not (Test-Path $destFolder -ErrorAction SilentlyContinue)) {
+                New-Item -Path $destFolder -ItemType Directory -ErrorAction Stop | Out-Null
+                if (-not (Test-Path $destFolder -ErrorAction SilentlyContinue)) {
+                    throw "Failed to create esxtop_output folder on datastore [$($datastore.Name)]."
+                }
+            }
+
+            $destFile = "$destFolder\$csvFileName"
+            Copy-DatastoreItem -Item $tempCsv -Destination $destFile -Force -ErrorAction Stop
+            $fileSizeKB = [math]::Round((Get-Item $tempCsv).Length / 1024, 1)
+            Write-Host "Uploaded ${fileSizeKB} KB to [$($datastore.Name)] esxtop_output/$csvFileName"
+        }
+    }
+    catch {
+        Write-Warning "Datastore upload failed: $($_.Exception.Message)"
+    }
+
+    Write-Host "Esxtop collection complete. $Iterations samples from $($vmHost.Name)."
+}

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1971,7 +1971,11 @@ function Get-EsxtopData {
 
     $cluster = Get-Cluster -Name $ClusterName -ErrorAction Stop
     $vmHost = $cluster | Get-VMHost |
-        Where-Object { $_.Name -like "$EsxiHostName*" -and $_.ConnectionState -eq 'Connected' } |
+        Where-Object {
+            $_.Name -like "$EsxiHostName*" -and
+            $_.ConnectionState -eq 'Connected' -and
+            $_.ExtensionData.Hardware.SystemInfo.Vendor -inotlike "Microsoft*"
+        } |
         Select-Object -First 1
 
     if ($null -eq $vmHost) {

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -533,6 +533,27 @@ Describe "Get-EsxtopData" {
             { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'nohost' } |
                 Should -Throw -ExpectedMessage "*No connected ESXi host matching*"
         }
+
+        It "Should exclude Microsoft fleet/Gen2 hosts" {
+            Mock Get-Cluster { [PSCustomObject]@{ Name = 'TestCluster' } } -ModuleName Microsoft.AVS.Management
+            Mock Get-VMHost {
+                @(
+                    [PSCustomObject]@{
+                        Name = 'fleethost1'
+                        ConnectionState = 'Connected'
+                        ExtensionData = [PSCustomObject]@{
+                            Hardware = [PSCustomObject]@{
+                                SystemInfo = [PSCustomObject]@{
+                                    Vendor = 'Microsoft Corporation'
+                                }
+                            }
+                        }
+                    }
+                )
+            } -ModuleName Microsoft.AVS.Management
+            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'fleet' } |
+                Should -Throw -ExpectedMessage "*No connected ESXi host matching*"
+        }
     }
 
     Context "Input Sanitization" {

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -9,7 +9,26 @@ BeforeAll {
             AVSAttribute([int]$timeoutMinutes) { $this.Timeout = New-TimeSpan -Minutes $timeoutMinutes }
         }
     }
-    
+
+    # Define stub functions for VMware cmdlets so Pester can mock them
+    # These are only created when the real cmdlets are not available (e.g. no PowerCLI installed)
+    $vmwareCmdlets = @(
+        'Get-Cluster', 'Get-VMHost', 'Get-Datastore', 'Get-View',
+        'Copy-DatastoreItem', 'New-PSDrive', 'Remove-PSDrive'
+    )
+    foreach ($cmdlet in $vmwareCmdlets) {
+        if (-not (Get-Command $cmdlet -ErrorAction SilentlyContinue)) {
+            Set-Item -Path "function:global:$cmdlet" -Value { param() $null }
+        }
+    }
+    # Always override Get-VMHost with a stub that accepts pipeline input,
+    # preventing mock failures when PowerCLI is not installed
+    function global:Get-VMHost {
+        param($Name, $Location, $State,
+              [Parameter(ValueFromPipeline=$true)]$InputObject)
+        process { $null }
+    }
+
     # Import the Management module
     $modulePath = Join-Path $PSScriptRoot ".." "Microsoft.AVS.Management" "Microsoft.AVS.Management.psd1"
     Import-Module $modulePath -Force

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -375,3 +375,168 @@ Describe "Set-ToolsRepo" {
         }
     }
 }
+
+Describe "Get-EsxtopData" {
+    Context "Parameter Validation" {
+        It "Should have ClusterName as mandatory String parameter" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['ClusterName']
+            $param.ParameterType.Name | Should -Be 'String'
+            ($param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Be $true
+        }
+
+        It "Should have EsxiHostName as mandatory String parameter" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['EsxiHostName']
+            $param.ParameterType.Name | Should -Be 'String'
+            ($param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Be $true
+        }
+
+        It "Should have Iterations as optional Int32 with default 6" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['Iterations']
+            $param.ParameterType.Name | Should -Be 'Int32'
+            ($param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Be $false
+        }
+
+        It "Should have IntervalSeconds as optional Int32 with ValidateRange(2,30)" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['IntervalSeconds']
+            $param.ParameterType.Name | Should -Be 'Int32'
+            $rangeAttr = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
+            $rangeAttr | Should -Not -BeNullOrEmpty
+            $rangeAttr.MinRange | Should -Be 2
+            $rangeAttr.MaxRange | Should -Be 30
+        }
+
+        It "Should have Iterations with ValidateRange(1,6)" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['Iterations']
+            $rangeAttr = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }
+            $rangeAttr | Should -Not -BeNullOrEmpty
+            $rangeAttr.MinRange | Should -Be 1
+            $rangeAttr.MaxRange | Should -Be 6
+        }
+
+        It "Should have OutputDatastoreName as optional String parameter" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['OutputDatastoreName']
+            $param.ParameterType.Name | Should -Be 'String'
+            ($param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Be $false
+        }
+
+        It "Should have ValidateNotNullOrEmpty on ClusterName" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['ClusterName']
+            $validateAttr = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateNotNullOrEmptyAttribute] }
+            $validateAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have ValidateNotNullOrEmpty on EsxiHostName" {
+            $cmd = Get-Command Get-EsxtopData
+            $param = $cmd.Parameters['EsxiHostName']
+            $validateAttr = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateNotNullOrEmptyAttribute] }
+            $validateAttr | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have HelpMessage on all parameters" {
+            $cmd = Get-Command Get-EsxtopData
+            foreach ($name in @('ClusterName', 'EsxiHostName', 'Iterations', 'IntervalSeconds', 'OutputDatastoreName')) {
+                $param = $cmd.Parameters[$name]
+                $paramAttr = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+                $paramAttr.HelpMessage | Should -Not -BeNullOrEmpty -Because "$name should have HelpMessage"
+            }
+        }
+    }
+
+    Context "AVSAttribute Verification" {
+        It "Should have AVSAttribute with 30 minute timeout" {
+            $cmd = Get-Command Get-EsxtopData
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr | Should -Not -BeNullOrEmpty
+            $avsAttr.Timeout.TotalMinutes | Should -Be 30
+        }
+
+        It "Should have AVSAttribute with UpdatesSDDC set to false" {
+            $cmd = Get-Command Get-EsxtopData
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr.UpdatesSDDC | Should -Be $false
+        }
+
+        It "Should have AVSAttribute timeout <= 60 minutes" {
+            $cmd = Get-Command Get-EsxtopData
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr.Timeout.TotalMinutes | Should -BeLessOrEqual 60
+        }
+    }
+
+    Context "Sampling Span Validation" {
+        BeforeEach {
+            Mock Limit-WildcardsandCodeInjectionCharacters { param($String) $String } -ModuleName Microsoft.AVS.Management
+        }
+
+        It "Should throw when (Iterations-1)*IntervalSeconds exceeds 30" {
+            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -Iterations 6 -IntervalSeconds 7 } |
+                Should -Throw -ExpectedMessage "*Esxtop sampling is limited to 30 seconds*"
+        }
+
+        It "Should not throw on sampling span validation when spacing equals 30" {
+            Mock Get-Cluster { throw "Expected: past validation" } -ModuleName Microsoft.AVS.Management
+            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -Iterations 6 -IntervalSeconds 6 } |
+                Should -Throw -Not -ExpectedMessage "*Esxtop sampling is limited*"
+        }
+
+        It "Should not throw on sampling span validation with single iteration" {
+            Mock Get-Cluster { throw "Expected: past validation" } -ModuleName Microsoft.AVS.Management
+            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -Iterations 1 -IntervalSeconds 30 } |
+                Should -Throw -Not -ExpectedMessage "*Esxtop sampling is limited*"
+        }
+    }
+
+    Context "Host Resolution" {
+        BeforeEach {
+            Mock Limit-WildcardsandCodeInjectionCharacters { param($String) $String } -ModuleName Microsoft.AVS.Management
+        }
+
+        It "Should throw when cluster is not found" {
+            Mock Get-Cluster { throw "Cluster 'BadCluster' not found." } -ModuleName Microsoft.AVS.Management
+            { Get-EsxtopData -ClusterName 'BadCluster' -EsxiHostName 'host1' } |
+                Should -Throw -ExpectedMessage "*BadCluster*"
+        }
+
+        It "Should throw when no matching connected host is found" {
+            Mock Get-Cluster { [PSCustomObject]@{ Name = 'TestCluster' } } -ModuleName Microsoft.AVS.Management
+            Mock Get-VMHost { @() } -ModuleName Microsoft.AVS.Management
+            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'nohost' } |
+                Should -Throw -ExpectedMessage "*No connected ESXi host matching*"
+        }
+    }
+
+    Context "Input Sanitization" {
+        It "Should call Limit-WildcardsandCodeInjectionCharacters for ClusterName and EsxiHostName" {
+            Mock Limit-WildcardsandCodeInjectionCharacters { param($String) $String } -ModuleName Microsoft.AVS.Management
+            Mock Get-Cluster { throw "stop here" } -ModuleName Microsoft.AVS.Management
+
+            try { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' } catch { }
+
+            Should -Invoke Limit-WildcardsandCodeInjectionCharacters -ModuleName Microsoft.AVS.Management -Times 2 -Exactly
+        }
+
+        It "Should sanitize OutputDatastoreName when provided" {
+            Mock Limit-WildcardsandCodeInjectionCharacters { param($String) $String } -ModuleName Microsoft.AVS.Management
+            Mock Get-Cluster { throw "stop here" } -ModuleName Microsoft.AVS.Management
+
+            try { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -OutputDatastoreName 'myDS' } catch { }
+
+            Should -Invoke Limit-WildcardsandCodeInjectionCharacters -ModuleName Microsoft.AVS.Management -Times 3 -Exactly
+        }
+    }
+
+    Context "CmdletBinding" {
+        It "Should have CmdletBinding attribute" {
+            $cmd = Get-Command Get-EsxtopData
+            $cmdletBindingAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
+            $cmdletBindingAttr | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -482,14 +482,18 @@ Describe "Get-EsxtopData" {
 
         It "Should not throw on sampling span validation when spacing equals 30" {
             Mock Get-Cluster { throw "Expected: past validation" } -ModuleName Microsoft.AVS.Management
-            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -Iterations 6 -IntervalSeconds 6 } |
-                Should -Throw -Not -ExpectedMessage "*Esxtop sampling is limited*"
+            $err = $null
+            try { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -Iterations 6 -IntervalSeconds 6 } catch { $err = $_ }
+            $err | Should -Not -BeNullOrEmpty
+            $err.Exception.Message | Should -Not -BeLike "*Esxtop sampling is limited*"
         }
 
         It "Should not throw on sampling span validation with single iteration" {
             Mock Get-Cluster { throw "Expected: past validation" } -ModuleName Microsoft.AVS.Management
-            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -Iterations 1 -IntervalSeconds 30 } |
-                Should -Throw -Not -ExpectedMessage "*Esxtop sampling is limited*"
+            $err = $null
+            try { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'host1' -Iterations 1 -IntervalSeconds 30 } catch { $err = $_ }
+            $err | Should -Not -BeNullOrEmpty
+            $err.Exception.Message | Should -Not -BeLike "*Esxtop sampling is limited*"
         }
     }
 
@@ -506,7 +510,7 @@ Describe "Get-EsxtopData" {
 
         It "Should throw when no matching connected host is found" {
             Mock Get-Cluster { [PSCustomObject]@{ Name = 'TestCluster' } } -ModuleName Microsoft.AVS.Management
-            Mock Get-VMHost { @() } -ModuleName Microsoft.AVS.Management
+            Mock Get-VMHost { return $null } -ModuleName Microsoft.AVS.Management
             { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'nohost' } |
                 Should -Throw -ExpectedMessage "*No connected ESXi host matching*"
         }

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -534,26 +534,6 @@ Describe "Get-EsxtopData" {
                 Should -Throw -ExpectedMessage "*No connected ESXi host matching*"
         }
 
-        It "Should exclude Microsoft fleet/Gen2 hosts" {
-            Mock Get-Cluster { [PSCustomObject]@{ Name = 'TestCluster' } } -ModuleName Microsoft.AVS.Management
-            Mock Get-VMHost {
-                @(
-                    [PSCustomObject]@{
-                        Name = 'fleethost1'
-                        ConnectionState = 'Connected'
-                        ExtensionData = [PSCustomObject]@{
-                            Hardware = [PSCustomObject]@{
-                                SystemInfo = [PSCustomObject]@{
-                                    Vendor = 'Microsoft Corporation'
-                                }
-                            }
-                        }
-                    }
-                )
-            } -ModuleName Microsoft.AVS.Management
-            { Get-EsxtopData -ClusterName 'TestCluster' -EsxiHostName 'fleet' } |
-                Should -Throw -ExpectedMessage "*No connected ESXi host matching*"
-        }
     }
 
     Context "Input Sanitization" {


### PR DESCRIPTION
This PR closes #

**The changes in this PR are as follows:**

1.Resolves the target host — finds the first connected ESXi host matching the given name prefix within the specified cluster.
2.Validates sampling constraints — ensures (Iterations - 1) * IntervalSeconds <= 30 seconds total span.
3.Connects to the Esxtop service — queries the vCenter ServiceManager for the Esxtop service on the target host, then obtains its view.
4.Collects snapshots — calls CounterInfo once, then loops FetchStats for the configured number of iterations with a sleep interval between samples, writing each sample as a timestamped CSV row to a local temp file.
5.Releases resources — calls FreeStats to free the Esxtop counters on the host.
6.Uploads results — copies the CSV to an esxtop_output/ folder on either a user-specified datastore or the cluster's first vSAN datastore, using a VimDatastore PSDrive.

**Why is this change required?**

AVS customers need to collect low-level ESXi performance metrics (CPU, memory, network, storage) when troubleshooting VM performance issues. Today there is no way to run esxtop on AVS hosts because SSH access to ESXi is not available to cloudadmins. This PR adds a Get-EsxtopData Run Command that collects esxtop snapshots through the vCenter ServiceManager API — removing the need for SSH — and uploads the results as a CSV file to a datastore for offline analysis.


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

