### PR TITLE
Set-ToolsRepo: Allow older VM Tools uploads without modifying metadata.json

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -597,6 +597,7 @@ function Set-ToolsRepo {
     # Initialize variables
     $new_folder = 'GuestStore'
     $archive_path = '/vmware/apps/vmtools/windows64/'
+    $normalizedArchivePath = if ($null -ne $archive_path) { $archive_path.Trim('/','\') } else { '' }
     $tmp_dir = $null
     $currentPSDrive = $null
     $successfulDatastores = @()
@@ -626,12 +627,9 @@ function Set-ToolsRepo {
 
         $tools_file = Join-Path -Path $tmp_dir.FullName -ChildPath "tools.zip"
 
-        # Download the tools file with progress (preserve ProgressPreference)
-        $oldProgressPreference = $null
+        # Download the tools file
         try {
             Write-Information "Downloading tools..." -InformationAction Continue
-            $oldProgressPreference = $ProgressPreference
-            $ProgressPreference = 'Continue'
             Invoke-WebRequest -Uri $ToolsURLPlain -OutFile $tools_file -ErrorAction Stop
 
             # Validate downloaded file
@@ -647,8 +645,6 @@ function Set-ToolsRepo {
             Write-Verbose "Downloaded file size: $($fileSize / 1MB) MB"
         } catch {
             throw "Failed to download tools file: $_"
-        } finally {
-            if ($null -ne $oldProgressPreference) { $ProgressPreference = $oldProgressPreference }
         }
 
         # Extract the archive
@@ -660,7 +656,10 @@ function Set-ToolsRepo {
         }
 
         # Find and validate tools version
-        $tools_path_new = Join-Path -Path $tmp_dir.FullName -ChildPath "${archive_path}vmtools-*"
+        $tools_path_new = Join-Path -Path $tmp_dir.FullName -ChildPath (
+            if ([string]::IsNullOrEmpty($normalizedArchivePath)) { 'vmtools-*' }
+            else { ("{0}/vmtools-*" -f $normalizedArchivePath) }
+        )
         $tools_directories = Get-ChildItem -Path $tools_path_new -Directory -ErrorAction SilentlyContinue
 
         if ($null -eq $tools_directories -or $tools_directories.Count -eq 0) {
@@ -732,7 +731,13 @@ function Set-ToolsRepo {
                 }
 
                 # Check existing tools versions to determine highest version
-                $tools_path = "DS:/$new_folder/$archive_path"
+                $baseDestPath = "DS:/$new_folder"
+                $destPath = if ([string]::IsNullOrEmpty($normalizedArchivePath)) {
+                    $baseDestPath
+                } else {
+                    Join-Path -Path $baseDestPath -ChildPath $normalizedArchivePath
+                }
+                $tools_path = $destPath
                 $highestExistingVersion = $null
                 $shouldUpdateTopLevelMetadata = $false
 
@@ -771,9 +776,6 @@ function Set-ToolsRepo {
                     # Use the discovered vmtools directory from the extracted archive as the source
                     $sourceDir = $tools_directories[0].FullName
 
-                    # Destination inside GuestStore should include archive_path so layout matches expected structure
-                    $destPath = "DS:/$new_folder$archive_path"
-
                     # Ensure destination folder exists on the datastore
                     if (-not (Test-Path -Path $destPath)) {
                         New-Item -ItemType Directory -Path $destPath -Force -ErrorAction Stop | Out-Null
@@ -792,6 +794,21 @@ function Set-ToolsRepo {
                         if (-not $versionMeta) { throw "metadata.json not found in copied version folder on $ds_name" }
 
                         Write-Information "Successfully copied $tools_version to $ds_name" -InformationAction Continue
+                    }
+
+                    # Ensure top-level GuestStore artifacts (for example, gueststore-vmtools) are present.
+                    # Keep metadata.json handling separate below so preserve/update rules stay unchanged.
+                    $topLevelSourceDir = Split-Path -Path $sourceDir -Parent
+                    if (-not [string]::IsNullOrEmpty($topLevelSourceDir) -and (Test-Path -Path $topLevelSourceDir)) {
+                        $topLevelFiles = Get-ChildItem -Path $topLevelSourceDir -File -ErrorAction SilentlyContinue |
+                            Where-Object { $_.Name -ne 'metadata.json' }
+                        foreach ($file in $topLevelFiles) {
+                            $destFilePath = Join-Path -Path $destPath -ChildPath $file.Name
+                            Copy-DatastoreItem -Item $file.FullName -Destination $destFilePath -Force -ErrorAction Stop
+                        }
+                        if ($topLevelFiles) {
+                            Write-Information "Ensured top-level GuestStore artifacts are present on $ds_name" -InformationAction Continue
+                        }
                     }
 
                     # Update top-level metadata.json only if new version is greater
@@ -887,11 +904,6 @@ function Set-ToolsRepo {
         # Ensure PSDrive is removed
         if (Get-PSDrive -Name DS -ErrorAction SilentlyContinue) {
             Remove-PSDrive -Name DS -Force -ErrorAction SilentlyContinue
-        }
-
-        # Remove temporary directory if it exists
-        if ($tmp_dir -and $tmp_dir.FullName -and (Test-Path -Path $tmp_dir.FullName)) {
-            Remove-Item -Path $tmp_dir.FullName -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -746,7 +746,8 @@ function Set-ToolsRepo {
 
                 if (Test-Path -Path $tools_path) {
                     try {
-                        $existing_dirs = Get-ChildItem -Path $tools_path -ErrorAction Stop | Where-Object Name -Match vmtools
+                        $existing_dirs = Get-ChildItem -Path $tools_path -Directory -ErrorAction Stop |
+                            Where-Object { $_.Name -match '^vmtools-\d+(?:\.\d+)*$' }
 
                         foreach ($existing_dir in $existing_dirs) {
                             $ver = $existing_dir.Name -replace 'vmtools-', ''
@@ -873,7 +874,7 @@ function Set-ToolsRepo {
                 }
 
                 if ($failedHosts.Count -gt 0) {
-                    Write-Warning "Failed to configure hosts for datastore $ds_name : $($failedHosts -join ', ')"
+                    throw "Failed to configure hosts for datastore $ds_name : $($failedHosts -join ', ')"
                 }
 
                 $successfulDatastores += $ds_name

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1,3 +1,6 @@
+# Load Classes first (must be loaded before other files that use them)
+. $PSScriptRoot\Classes.ps1
+
 <# Private Function Import #>
 . $PSScriptRoot\AVSGenericUtils.ps1
 . $PSScriptRoot\AVSvSANUtils.ps1
@@ -621,11 +624,13 @@ function Set-ToolsRepo {
             throw "Failed to create temporary directory: $_"
         }
 
-        $tools_file = Join-Path -Path $tmp_dir -ChildPath "tools.zip"
+        $tools_file = Join-Path -Path $tmp_dir.FullName -ChildPath "tools.zip"
 
-        # Download the tools file with progress
+        # Download the tools file with progress (preserve ProgressPreference)
+        $oldProgressPreference = $null
         try {
             Write-Information "Downloading tools..." -InformationAction Continue
+            $oldProgressPreference = $ProgressPreference
             $ProgressPreference = 'Continue'
             Invoke-WebRequest -Uri $ToolsURLPlain -OutFile $tools_file -ErrorAction Stop
 
@@ -642,6 +647,8 @@ function Set-ToolsRepo {
             Write-Verbose "Downloaded file size: $($fileSize / 1MB) MB"
         } catch {
             throw "Failed to download tools file: $_"
+        } finally {
+            if ($null -ne $oldProgressPreference) { $ProgressPreference = $oldProgressPreference }
         }
 
         # Extract the archive
@@ -653,7 +660,7 @@ function Set-ToolsRepo {
         }
 
         # Find and validate tools version
-        $tools_path_new = Join-Path -Path $tmp_dir -ChildPath "${archive_path}vmtools-*"
+        $tools_path_new = Join-Path -Path $tmp_dir.FullName -ChildPath "${archive_path}vmtools-*"
         $tools_directories = Get-ChildItem -Path $tools_path_new -Directory -ErrorAction SilentlyContinue
 
         if ($null -eq $tools_directories -or $tools_directories.Count -eq 0) {
@@ -724,39 +731,84 @@ function Set-ToolsRepo {
                     }
                 }
 
-                # Check existing tools versions
-                $do_not_copy = $false
+                # Check existing tools versions to determine highest version
                 $tools_path = "DS:/$new_folder/$archive_path"
+                $highestExistingVersion = $null
+                $shouldUpdateTopLevelMetadata = $false
 
                 if (Test-Path -Path $tools_path) {
                     try {
-                        # $existing_dirs = Get-ChildItem -Path $tools_path -Directory -ErrorAction Stop
                         $existing_dirs = Get-ChildItem -Path $tools_path -ErrorAction Stop | Where-Object Name -Match vmtools
 
                         foreach ($existing_dir in $existing_dirs) {
                             $ver = $existing_dir.Name -replace 'vmtools-', ''
-                            if ([version]$ver -ge [version]$tools_short_version) {
-                                $do_not_copy = $true
-                                Write-Information "Found newer or equal version ($ver) on $ds_name" -InformationAction Continue
-                                break
+                            if ($null -eq $highestExistingVersion -or [version]$ver -gt [version]$highestExistingVersion) {
+                                $highestExistingVersion = $ver
                             }
+                        }
+
+                        if ($highestExistingVersion) {
+                            Write-Information "Current highest version on $ds_name is $highestExistingVersion" -InformationAction Continue
                         }
                     } catch {
                         Write-Warning "Failed to check existing versions on $ds_name : $_"
-                        # Continue with copy operation if we can't verify existing versions
                     }
                 }
 
-                # Copy files if needed
-                if (-not $do_not_copy) {
-                    try {
-                        Write-Information "Copying $tools_version to $ds_name..." -InformationAction Continue
-                        # $sourcePath = $tools_directories[0].ResolvedTarget
-                        Copy-DatastoreItem -Item "$tmp_dir/vmware" -Destination "DS:/$new_folder" -Recurse -Force -ErrorAction Stop
-                        Write-Information "Successfully copied tools to $ds_name" -InformationAction Continue
-                    } catch {
-                        throw "Failed to copy tools to $ds_name : $_"
+                # Determine if we should update the top-level metadata.json
+                # Only update if new version is greater than the highest existing version
+                if ($null -eq $highestExistingVersion -or [version]$tools_short_version -gt [version]$highestExistingVersion) {
+                    $shouldUpdateTopLevelMetadata = $true
+                    Write-Information "New version ($tools_short_version) is greater than existing ($highestExistingVersion). Top-level metadata.json will be updated." -InformationAction Continue
+                } else {
+                    Write-Information "New version ($tools_short_version) is not greater than existing ($highestExistingVersion). Top-level metadata.json will be preserved." -InformationAction Continue
+                }
+
+                # Always copy the new version (older versions are allowed)
+                try {
+                    Write-Information "Copying $tools_version to $ds_name..." -InformationAction Continue
+
+                    # Use the discovered vmtools directory from the extracted archive as the source
+                    $sourceDir = $tools_directories[0].FullName
+
+                    # Destination inside GuestStore should include archive_path so layout matches expected structure
+                    $destPath = "DS:/$new_folder$archive_path"
+
+                    # Ensure destination folder exists on the datastore
+                    if (-not (Test-Path -Path $destPath)) {
+                        New-Item -ItemType Directory -Path $destPath -Force -ErrorAction Stop | Out-Null
                     }
+
+                    # Check if this version already exists on the datastore
+                    $versionDestPath = Join-Path $destPath $tools_version
+                    if (Test-Path -Path $versionDestPath) {
+                        Write-Information "Version $tools_version already exists on $ds_name. Skipping copy." -InformationAction Continue
+                    } else {
+                        # Copy the vmtools-{version} folder itself (preserves folder structure)
+                        Copy-DatastoreItem -Item $sourceDir -Destination $destPath -Recurse -Force -ErrorAction Stop
+
+                        # Verify metadata.json exists in the copied version folder
+                        $versionMeta = Get-ChildItem -Path $versionDestPath -Filter metadata.json -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+                        if (-not $versionMeta) { throw "metadata.json not found in copied version folder on $ds_name" }
+
+                        Write-Information "Successfully copied $tools_version to $ds_name" -InformationAction Continue
+                    }
+
+                    # Update top-level metadata.json only if new version is greater
+                    if ($shouldUpdateTopLevelMetadata) {
+                        $sourceMetadata = Get-ChildItem -Path $sourceDir -Filter metadata.json -ErrorAction SilentlyContinue | Select-Object -First 1
+                        if ($sourceMetadata) {
+                            $topLevelMetadataPath = Join-Path $destPath "metadata.json"
+                            Copy-DatastoreItem -Item $sourceMetadata.FullName -Destination $topLevelMetadataPath -Force -ErrorAction Stop
+                            Write-Information "Updated top-level metadata.json on $ds_name to version $tools_short_version" -InformationAction Continue
+                        } else {
+                            Write-Warning "Source metadata.json not found at root of $tools_version package"
+                        }
+                    } else {
+                        Write-Information "Top-level metadata.json on $ds_name preserved (not overwritten)" -InformationAction Continue
+                    }
+                } catch {
+                    throw "Failed to copy tools to $ds_name : $_"
                 }
 
                 # Configure hosts
@@ -801,7 +853,7 @@ function Set-ToolsRepo {
                 }
 
                 if ($failedHosts.Count -gt 0) {
-                    throw "Failed to configure hosts: $($failedHosts -join ', ')"
+                    Write-Warning "Failed to configure hosts for datastore $ds_name : $($failedHosts -join ', ')"
                 }
 
                 $successfulDatastores += $ds_name
@@ -835,6 +887,11 @@ function Set-ToolsRepo {
         # Ensure PSDrive is removed
         if (Get-PSDrive -Name DS -ErrorAction SilentlyContinue) {
             Remove-PSDrive -Name DS -Force -ErrorAction SilentlyContinue
+        }
+
+        # Remove temporary directory if it exists
+        if ($tmp_dir -and $tmp_dir.FullName -and (Test-Path -Path $tmp_dir.FullName)) {
+            Remove-Item -Path $tmp_dir.FullName -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
 }
@@ -1820,14 +1877,14 @@ Function Get-vSANDataInTransitEncryptionStatus {
 
 Function Set-vSANDataInTransitEncryption {
   <#
-    .DESCRIPTION
-        Enable/Disable vSAN Data-In-Transit Encryption for clusters of a SDDC.
-        There may be a performance impact when vSAN Data-In-Transit Encryption is enabled. Refer :  https://blogs.vmware.com/virtualblocks/2021/08/12/storageminute-vsan-data-encryption-performance/
-    .PARAMETER ClusterName
-        Name of the cluster. Leave blank if required to enable for whole SDDC else enter comma separated list of names.
-    .PARAMETER Enable
-        Specify True/False to Enable/Disable the feature.
-    #>
+    .DESCRIPTION
+        Enable/Disable vSAN Data-In-Transit Encryption for clusters of a SDDC.
+        There may be a performance impact when vSAN Data-In-Transit Encryption is enabled. Refer :  https://blogs.vmware.com/virtualblocks/2021/08/12/storageminute-vsan-data-encryption-performance/
+    .PARAMETER ClusterName
+        Name of the cluster. Leave blank if required to enable for whole SDDC else enter comma separated list of names.
+    .PARAMETER Enable
+        Specify True/False to Enable/Disable the feature.
+    #>
     [CmdletBinding()]
     [AVSAttribute(10, UpdatesSDDC = $false)]
     param (
@@ -1844,8 +1901,8 @@ Function Set-vSANDataInTransitEncryption {
             $ClusterNamesArray = Convert-StringToArray -String $ClusterNamesParsed
         }
         Write-Host "Enable value is $Enable"
-        $TagName = "vSAN Data-In-Transit Encryption" 
-            $InfoMessage = "Info - There may be a performance impact when vSAN Data-In-Transit Encryption is enabled. Refer :  https://blogs.vmware.com/virtualblocks/2021/08/12/storageminute-vsan-data-encryption-performance/"
+        $TagName = "vSAN Data-In-Transit Encryption"
+            $InfoMessage = "Info - There may be a performance impact when vSAN Data-In-Transit Encryption is enabled. Refer :  https://blogs.vmware.com/virtualblocks/2021/08/12/storageminute-vsan-data-encryption-performance/"
     }
     process {
         If ([string]::IsNullOrEmpty($ClusterNamesArray)) {

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -746,8 +746,11 @@ function Set-ToolsRepo {
 
                 if (Test-Path -Path $tools_path) {
                     try {
-                        $existing_dirs = Get-ChildItem -Path $tools_path -Directory -ErrorAction Stop |
-                            Where-Object { $_.Name -match '^vmtools-\d+(?:\.\d+)*$' }
+                        $existing_dirs = Get-ChildItem -Path $tools_path -ErrorAction Stop |
+                            Where-Object {
+                                $_.PSIsContainer -and
+                                $_.Name -match '^vmtools-\d'
+                            }
 
                         foreach ($existing_dir in $existing_dirs) {
                             $ver = $existing_dir.Name -replace 'vmtools-', ''

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -1,6 +1,3 @@
-# Load Classes first (must be loaded before other files that use them)
-. $PSScriptRoot\Classes.ps1
-
 <# Private Function Import #>
 . $PSScriptRoot\AVSGenericUtils.ps1
 . $PSScriptRoot\AVSvSANUtils.ps1

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -656,10 +656,12 @@ function Set-ToolsRepo {
         }
 
         # Find and validate tools version
-        $tools_path_new = Join-Path -Path $tmp_dir.FullName -ChildPath (
-            if ([string]::IsNullOrEmpty($normalizedArchivePath)) { 'vmtools-*' }
-            else { ("{0}/vmtools-*" -f $normalizedArchivePath) }
-        )
+        if ([string]::IsNullOrEmpty($normalizedArchivePath)) {
+            $toolsChildPath = 'vmtools-*'
+        } else {
+            $toolsChildPath = "{0}/vmtools-*" -f $normalizedArchivePath
+        }
+        $tools_path_new = Join-Path -Path $tmp_dir.FullName -ChildPath $toolsChildPath
         $tools_directories = Get-ChildItem -Path $tools_path_new -Directory -ErrorAction SilentlyContinue
 
         if ($null -eq $tools_directories -or $tools_directories.Count -eq 0) {
@@ -706,7 +708,8 @@ function Set-ToolsRepo {
                     $Dsbrowser = Get-View -Id $Datastore.Extensiondata.Browser -ErrorAction Stop
                     $spec = New-Object VMware.Vim.HostDatastoreBrowserSearchSpec
                     $spec.Query += New-Object VMware.Vim.FolderFileQuery
-                    $searchResult = $dsBrowser.SearchDatastore("[$ds_name] \", $spec)
+                    $datastoreRoot = "[{0}]" -f $ds_name
+                    $searchResult = $dsBrowser.SearchDatastore($datastoreRoot, $spec)
                     $folderObj = $searchResult.File | Where-Object { $_.FriendlyName -eq $new_folder }
                 } catch {
                     throw "Failed to browse datastore $ds_name : $_"
@@ -722,7 +725,7 @@ function Set-ToolsRepo {
                     }
 
                     # Verify folder creation
-                    $searchResult = $dsBrowser.SearchDatastore("[$ds_name] \", $spec)
+                    $searchResult = $dsBrowser.SearchDatastore($datastoreRoot, $spec)
                     $folderObj = $searchResult.File | Where-Object { $_.FriendlyName -eq $new_folder }
 
                     if ($null -eq $folderObj) {

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -466,10 +466,14 @@ Describe "Set-ToolsRepo" {
                 # Validates: when incoming version is older than existing highest, top-level metadata is not overwritten.
                 $IncomingVersion = '12.3.0'
                 $ExistingVersion = '12.4.0'
-                Initialize-SetToolsRepoScenarioMocks -ToolsShortVersion $IncomingVersion -HighestExistingVersion $ExistingVersion -VersionAlreadyExists $true
+                Initialize-SetToolsRepoScenarioMocks -ToolsShortVersion $IncomingVersion -HighestExistingVersion $ExistingVersion -VersionAlreadyExists $false
                 $secureUrl = ConvertTo-TestSecureString 'https://example.com/tools.zip'
 
                 { Set-ToolsRepo -ToolsURL $secureUrl } | Should -Not -Throw
+
+                Assert-MockCalled Copy-DatastoreItem -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -Scope It -ParameterFilter {
+                    $Destination -like "*/vmtools-$IncomingVersion"
+                }
 
                 Assert-MockCalled Copy-DatastoreItem -ModuleName Microsoft.AVS.Management -Times 0 -Exactly -Scope It -ParameterFilter {
                     $Destination -like '*metadata.json'

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -244,7 +244,10 @@ Describe "Set-ToolsRepo" {
         }
 
         It "Should throw when vmtools directory not found in archive" {
-            Mock Get-ChildItem { $null } -ModuleName Microsoft.AVS.Management
+            Mock Get-ChildItem {
+                param($Path, $Filter, [switch]$Directory, [switch]$File, [switch]$Recurse)
+                $null
+            } -ModuleName Microsoft.AVS.Management
 
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
             { Set-ToolsRepo -ToolsURL $secureUrl } |
@@ -266,13 +269,14 @@ Describe "Set-ToolsRepo" {
             Mock Test-Path { $true } -ModuleName Microsoft.AVS.Management
             Mock Get-Item { [PSCustomObject]@{ Length = 1024 } } -ModuleName Microsoft.AVS.Management
             Mock Expand-Archive { } -ModuleName Microsoft.AVS.Management
-            Mock Get-ChildItem {
-                [PSCustomObject]@{ Name = "vmtools-12.3.0" }
-            } -ModuleName Microsoft.AVS.Management
             Mock Join-Path { "$Path/$ChildPath" } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Path -like 'DS:*' }
         }
 
         It "Should throw when no vSAN datastores found" {
+            Mock Get-ChildItem {
+                param($Path, $Filter, [switch]$Directory, [switch]$File, [switch]$Recurse)
+                [PSCustomObject]@{ Name = "vmtools-12.3.0" }
+            } -ModuleName Microsoft.AVS.Management
             Mock Get-Datastore { $null } -ModuleName Microsoft.AVS.Management
 
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
@@ -281,6 +285,10 @@ Describe "Set-ToolsRepo" {
         }
 
         It "Should throw when Get-Datastore fails" {
+            Mock Get-ChildItem {
+                param($Path, $Filter, [switch]$Directory, [switch]$File, [switch]$Recurse)
+                [PSCustomObject]@{ Name = "vmtools-12.3.0" }
+            } -ModuleName Microsoft.AVS.Management
             Mock Get-Datastore { throw "Connection error" } -ModuleName Microsoft.AVS.Management
 
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
@@ -336,10 +344,23 @@ Describe "Set-ToolsRepo" {
     InModuleScope 'Microsoft.AVS.Management' {
         Context "Version and metadata decision logic (mock-only)" {
             BeforeAll {
+                $script:originalTemp = $env:TEMP
+                $script:originalTmp = $env:TMP
+                $script:testTempDir = Join-Path $TestDrive 'temp'
+                New-Item -Path $script:testTempDir -ItemType Directory -Force | Out-Null
+                $env:TEMP = $script:testTempDir
+                $env:TMP = $script:testTempDir
+
                 function ConvertTo-TestSecureString {
                     param([string]$PlainText)
                     return ConvertTo-SecureString -String $PlainText -AsPlainText -Force
                 }
+
+                Mock Expand-Archive { } -ModuleName Microsoft.AVS.Management
+
+                # Shadow the real Get-EsxCli cmdlet with a plain function so Pester
+                # can mock it without PowerCLI's VMHost[] type constraint blocking.
+                function Get-EsxCli { param([switch]$V2, $VMHost) }
 
                 function Initialize-SetToolsRepoScenarioMocks {
                     param(
@@ -349,17 +370,34 @@ Describe "Set-ToolsRepo" {
                     )
 
                     $script:toolsVersion = "vmtools-$ToolsShortVersion"
-                    $script:tempRoot = "C:\mock\newtools_test"
-                    $script:sourceDir = "$script:tempRoot\vmware\apps\vmtools\windows64\$script:toolsVersion"
-                    $script:topLevelSourceDir = "$script:tempRoot\vmware\apps\vmtools\windows64"
+                    $script:tempRoot = Join-Path $TestDrive 'newtools_test'
+                    $script:sourceDir = Join-Path $TestDrive "vmtools-$ToolsShortVersion"
+                    $script:topLevelSourceDir = Join-Path $script:tempRoot 'vmware' 'apps' 'vmtools' 'windows64'
                     $script:destPath = "DS:/GuestStore/vmware/apps/vmtools/windows64"
                     $script:versionDestPath = "$script:destPath/$script:toolsVersion"
                     $script:highestExistingVersion = $HighestExistingVersion
                     $script:versionAlreadyExists = $VersionAlreadyExists
 
+                    # Create fake extracted directory and metadata.json under $TestDrive
+                    [System.IO.Directory]::CreateDirectory($script:sourceDir) | Out-Null
+                    [System.IO.File]::WriteAllText((Join-Path $script:sourceDir 'metadata.json'), '{}')
+
                     # URL validation and download path are always mocked; no network access.
                     Mock Invoke-WebRequest {
-                        if ($Method -eq 'Head') { return [PSCustomObject]@{ StatusCode = 200 } }
+                        if ($Method -eq 'Head') {
+                            return [PSCustomObject]@{ StatusCode = 200 }
+                        }
+
+                        if ($OutFile) {
+                            $parentPath = [System.IO.Path]::GetDirectoryName($OutFile)
+                            if (-not [string]::IsNullOrEmpty($parentPath)) {
+                                [System.IO.Directory]::CreateDirectory($parentPath) | Out-Null
+                            }
+
+                            [System.IO.File]::WriteAllText($OutFile, 'dummy')
+                            return [PSCustomObject]@{ StatusCode = 200 }
+                        }
+
                         return $null
                     } -ModuleName Microsoft.AVS.Management
 
@@ -386,19 +424,33 @@ Describe "Set-ToolsRepo" {
                     } -ModuleName Microsoft.AVS.Management
 
                     Mock Get-ChildItem {
-                        # Locate extracted vmtools-* directory
-                        if ($Directory) {
+                        param(
+                            $Path,
+                            $Filter,
+                            [switch]$Directory,
+                            [switch]$File,
+                            [switch]$Recurse
+                        )
+
+                        # vmtools-* directory discovery: production passes
+                        # <tmp>\vmware\apps\vmtools\windows64\vmtools-* with -Directory
+                        if ($Directory -and $Path -like '*windows64*') {
                             return @([PSCustomObject]@{ Name = $script:toolsVersion; FullName = $script:sourceDir })
                         }
 
                         # Existing datastore versions used to compute highestExistingVersion
                         if ($Path -eq $script:destPath -and -not $Filter -and -not $Recurse -and -not $File) {
-                            return @([PSCustomObject]@{ Name = "vmtools-$script:highestExistingVersion"; FullName = "$script:destPath/vmtools-$script:highestExistingVersion" })
+                            return @([PSCustomObject]@{ Name = "vmtools-$script:highestExistingVersion"; FullName = "$script:destPath/vmtools-$script:highestExistingVersion"; PSIsContainer = $true })
                         }
 
                         # Source metadata is present so update path is testable
                         if ($Path -eq $script:sourceDir -and $Filter -eq 'metadata.json') {
                             return @([PSCustomObject]@{ Name = 'metadata.json'; FullName = "$script:sourceDir\metadata.json" })
+                        }
+
+                        # Copied version folder metadata check after Copy-DatastoreItem
+                        if ($Path -eq $script:versionDestPath -and $Filter -eq 'metadata.json') {
+                            return @([PSCustomObject]@{ Name = 'metadata.json'; FullName = "$script:versionDestPath/metadata.json" })
                         }
 
                         return @()
@@ -445,7 +497,7 @@ Describe "Set-ToolsRepo" {
                     } -ModuleName Microsoft.AVS.Management
 
                     $script:setObj = New-Object psobject
-                    Add-Member -InputObject $script:setObj -MemberType ScriptMethod -Name CreateArgs -Value { return [PSCustomObject]@{ url = $null } } -Force
+                    Add-Member -InputObject $script:setObj -MemberType ScriptMethod -Name CreateArgs -Value { return @{ url = $null } } -Force
                     Add-Member -InputObject $script:setObj -MemberType ScriptMethod -Name invoke -Value { param($arguments) return $true } -Force
                     $script:esxcli = [PSCustomObject]@{
                         system = [PSCustomObject]@{
@@ -456,10 +508,22 @@ Describe "Set-ToolsRepo" {
                             }
                         }
                     }
-                    Mock Get-EsxCli { $script:esxcli } -ModuleName Microsoft.AVS.Management
+                    Mock Get-EsxCli {
+                        param(
+                            [switch]$V2,
+                            [object]$VMHost
+                        )
+
+                        return $script:esxcli
+                    } -ModuleName Microsoft.AVS.Management
 
                     Mock Copy-DatastoreItem { } -ModuleName Microsoft.AVS.Management
                 }
+            }
+
+            AfterAll {
+                $env:TEMP = $script:originalTemp
+                $env:TMP = $script:originalTmp
             }
 
             It "Older version upload preserves top-level metadata.json" {
@@ -472,7 +536,7 @@ Describe "Set-ToolsRepo" {
                 { Set-ToolsRepo -ToolsURL $secureUrl } | Should -Not -Throw
 
                 Assert-MockCalled Copy-DatastoreItem -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -Scope It -ParameterFilter {
-                    $Destination -like "*/vmtools-$IncomingVersion"
+                    $Destination -like '*windows64'
                 }
 
                 Assert-MockCalled Copy-DatastoreItem -ModuleName Microsoft.AVS.Management -Times 0 -Exactly -Scope It -ParameterFilter {
@@ -543,7 +607,10 @@ Describe "Set-ToolsRepo" {
             Mock Test-Path { $true } -ModuleName Microsoft.AVS.Management
             Mock Get-Item { [PSCustomObject]@{ Length = 1024 } } -ModuleName Microsoft.AVS.Management
             Mock Expand-Archive { } -ModuleName Microsoft.AVS.Management
-            Mock Get-ChildItem { [PSCustomObject]@{ Name = "vmtools-$IncomingVersion" } } -ModuleName Microsoft.AVS.Management
+            Mock Get-ChildItem {
+                param($Path, $Filter, [switch]$Directory, [switch]$File, [switch]$Recurse)
+                [PSCustomObject]@{ Name = "vmtools-$IncomingVersion" }
+            } -ModuleName Microsoft.AVS.Management
             Mock Get-Datastore {
                 [PSCustomObject]@{
                     Name = "vsanDatastore"

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -9,7 +9,15 @@ BeforeAll {
             AVSAttribute([int]$timeoutMinutes) { $this.Timeout = New-TimeSpan -Minutes $timeoutMinutes }
         }
     }
-    
+
+    if (-not ('VMware.VimAutomation.ViCore.Types.V1.Inventory.Folder' -as [type])) {
+        Add-Type @"
+namespace VMware.VimAutomation.ViCore.Types.V1.Inventory {
+    public class Folder {}
+}
+"@
+    }
+
     # Import the Management module
     $modulePath = Join-Path $PSScriptRoot ".." "Microsoft.AVS.Management" "Microsoft.AVS.Management.psd1"
     Import-Module $modulePath -Force
@@ -82,46 +90,46 @@ Describe "Set-ToolsRepo" {
     Context "URL Pattern Validation" {
         It "Should throw for non-HTTP/HTTPS URL" {
             $secureUrl = ConvertTo-TestSecureString "ftp://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*ToolsURL must be a valid HTTP or HTTPS URL*"
         }
 
         It "Should throw for URL without protocol" {
             $secureUrl = ConvertTo-TestSecureString "example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*ToolsURL must be a valid HTTP or HTTPS URL*"
         }
 
         It "Should throw for file:// URL" {
             $secureUrl = ConvertTo-TestSecureString "file:///path/to/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*ToolsURL must be a valid HTTP or HTTPS URL*"
         }
 
         It "Should proceed past URL validation for valid HTTP URL" {
             Mock Invoke-WebRequest { throw "Expected network call" } -ModuleName Microsoft.AVS.Management
             $secureUrl = ConvertTo-TestSecureString "http://example.com/tools.zip"
-            
+
             # Should fail at network request, not URL validation
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Unable to access the provided URL*"
         }
 
         It "Should proceed past URL validation for valid HTTPS URL" {
             Mock Invoke-WebRequest { throw "Expected network call" } -ModuleName Microsoft.AVS.Management
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            
+
             # Should fail at network request, not URL validation
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Unable to access the provided URL*"
         }
 
         It "Should proceed past URL validation for HTTPS URL with query parameters" {
             Mock Invoke-WebRequest { throw "Expected network call" } -ModuleName Microsoft.AVS.Management
             $secureUrl = ConvertTo-TestSecureString "https://storage.example.com/tools.zip?token=secret123&sig=abc"
-            
+
             # Should fail at network request, not URL validation
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Unable to access the provided URL*"
         }
     }
@@ -130,35 +138,35 @@ Describe "Set-ToolsRepo" {
         It "Should throw when URL is not accessible" {
             Mock Invoke-WebRequest { throw "404 Not Found" } -ModuleName Microsoft.AVS.Management
             $secureUrl = ConvertTo-TestSecureString "https://example.com/nonexistent.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Unable to access the provided URL*"
         }
 
         It "Should throw when URL returns non-200 status code" {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 403 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 403 }
             } -ModuleName Microsoft.AVS.Management
             $secureUrl = ConvertTo-TestSecureString "https://example.com/forbidden.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*URL returned status code: 403*"
         }
     }
 
     Context "Temporary Directory Creation" {
         BeforeAll {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
         }
 
         It "Should throw when temporary directory cannot be created" {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
             Mock New-Item { throw "Permission denied" } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Failed to create temporary directory*"
         }
     }
@@ -166,21 +174,21 @@ Describe "Set-ToolsRepo" {
     Context "File Download Validation" {
         BeforeAll {
             # Mock successful HEAD request
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
-            
+
             # Mock successful temp directory creation
-            Mock New-Item { 
-                [PSCustomObject]@{ FullName = "/tmp/newtools_test" } 
+            Mock New-Item {
+                [PSCustomObject]@{ FullName = "/tmp/newtools_test" }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' }
         }
 
         It "Should throw when download fails" {
             Mock Invoke-WebRequest { throw "Download failed" } -ModuleName Microsoft.AVS.Management -ParameterFilter { $OutFile }
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Failed to download tools file*"
         }
 
@@ -188,23 +196,23 @@ Describe "Set-ToolsRepo" {
             Mock Invoke-WebRequest { } -ModuleName Microsoft.AVS.Management -ParameterFilter { $OutFile }
             Mock Test-Path { $true } -ModuleName Microsoft.AVS.Management
             Mock Get-Item { [PSCustomObject]@{ Length = 0 } } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Downloaded file is empty*"
         }
     }
 
     Context "Archive Extraction Validation" {
         BeforeAll {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
-            
-            Mock New-Item { 
-                [PSCustomObject]@{ FullName = "/tmp/newtools_test" } 
+
+            Mock New-Item {
+                [PSCustomObject]@{ FullName = "/tmp/newtools_test" }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' }
-            
+
             Mock Invoke-WebRequest { } -ModuleName Microsoft.AVS.Management -ParameterFilter { $OutFile }
             Mock Test-Path { $true } -ModuleName Microsoft.AVS.Management
             Mock Get-Item { [PSCustomObject]@{ Length = 1024 } } -ModuleName Microsoft.AVS.Management
@@ -212,23 +220,23 @@ Describe "Set-ToolsRepo" {
 
         It "Should throw when archive extraction fails" {
             Mock Expand-Archive { throw "Invalid archive" } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Failed to extract tools archive*"
         }
     }
 
     Context "VMtools Directory Validation" {
         BeforeAll {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
-            
-            Mock New-Item { 
-                [PSCustomObject]@{ FullName = "/tmp/newtools_test" } 
+
+            Mock New-Item {
+                [PSCustomObject]@{ FullName = "/tmp/newtools_test" }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' }
-            
+
             Mock Invoke-WebRequest { } -ModuleName Microsoft.AVS.Management -ParameterFilter { $OutFile }
             Mock Test-Path { $true } -ModuleName Microsoft.AVS.Management
             Mock Get-Item { [PSCustomObject]@{ Length = 1024 } } -ModuleName Microsoft.AVS.Management
@@ -237,46 +245,46 @@ Describe "Set-ToolsRepo" {
 
         It "Should throw when vmtools directory not found in archive" {
             Mock Get-ChildItem { $null } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Unable to find vmtools directory*"
         }
     }
 
     Context "vSAN Datastore Validation" {
         BeforeAll {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
-            
-            Mock New-Item { 
-                [PSCustomObject]@{ FullName = "/tmp/newtools_test" } 
-            } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' }
-            
+
+            Mock New-Item {
+                [PSCustomObject]@{ FullName = "/tmp/newtools_test"; Name = "newtools_test" }
+            } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' -and $Path -match '^\.([\\/])newtools_' }
+
             Mock Invoke-WebRequest { } -ModuleName Microsoft.AVS.Management -ParameterFilter { $OutFile }
             Mock Test-Path { $true } -ModuleName Microsoft.AVS.Management
             Mock Get-Item { [PSCustomObject]@{ Length = 1024 } } -ModuleName Microsoft.AVS.Management
             Mock Expand-Archive { } -ModuleName Microsoft.AVS.Management
-            Mock Get-ChildItem { 
-                [PSCustomObject]@{ Name = "vmtools-12.3.0" } 
+            Mock Get-ChildItem {
+                [PSCustomObject]@{ Name = "vmtools-12.3.0" }
             } -ModuleName Microsoft.AVS.Management
-            Mock Join-Path { "/tmp/newtools_test/vmware/apps/vmtools/windows64/vmtools-*" } -ModuleName Microsoft.AVS.Management
+            Mock Join-Path { "$Path/$ChildPath" } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Path -like 'DS:*' }
         }
 
         It "Should throw when no vSAN datastores found" {
             Mock Get-Datastore { $null } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*No vSAN datastores found*"
         }
 
         It "Should throw when Get-Datastore fails" {
             Mock Get-Datastore { throw "Connection error" } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Failed to retrieve vSAN datastores*"
         }
     }
@@ -284,92 +292,268 @@ Describe "Set-ToolsRepo" {
     Context "SecureString Handling" {
         It "Should pass converted SecureString URL to HEAD request" {
             $capturedUri = $null
-            Mock Invoke-WebRequest { 
+            Mock Invoke-WebRequest {
                 $capturedUri = $Uri
                 throw "Stop here for test"
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
-            
+
             $testUrl = "https://example.com/tools.zip?token=secret123"
             $secureUrl = ConvertTo-TestSecureString $testUrl
-            
+
             try { Set-ToolsRepo -ToolsURL $secureUrl } catch { }
-            
-            Should -Invoke Invoke-WebRequest -ModuleName Microsoft.AVS.Management -ParameterFilter { 
-                $Uri -eq $testUrl -and $Method -eq 'Head' 
+
+            Should -Invoke Invoke-WebRequest -ModuleName Microsoft.AVS.Management -ParameterFilter {
+                $Uri -eq $testUrl -and $Method -eq 'Head'
             }
         }
 
         It "Should pass converted SecureString URL to download request" {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
-            
-            Mock New-Item { 
-                [PSCustomObject]@{ FullName = "/tmp/newtools_test" } 
+
+            Mock New-Item {
+                [PSCustomObject]@{ FullName = "/tmp/newtools_test" }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' }
-            
+
             Mock Invoke-WebRequest { throw "Stop here" } -ModuleName Microsoft.AVS.Management -ParameterFilter { $OutFile }
-            
+
             $testUrl = "https://example.com/tools.zip?token=secret123"
             $secureUrl = ConvertTo-TestSecureString $testUrl
-            
+
             try { Set-ToolsRepo -ToolsURL $secureUrl } catch { }
-            
-            Should -Invoke Invoke-WebRequest -ModuleName Microsoft.AVS.Management -ParameterFilter { 
-                $Uri -eq $testUrl -and $OutFile 
+
+            Should -Invoke Invoke-WebRequest -ModuleName Microsoft.AVS.Management -ParameterFilter {
+                $Uri -eq $testUrl -and $OutFile
+            }
+        }
+    }
+
+    if (-not (Get-Module Microsoft.AVS.Management)) {
+        Import-Module (Join-Path $PSScriptRoot ".." "Microsoft.AVS.Management" "Microsoft.AVS.Management.psd1") -Force
+    }
+
+    InModuleScope 'Microsoft.AVS.Management' {
+        Context "Version and metadata decision logic (mock-only)" {
+            BeforeAll {
+                function ConvertTo-TestSecureString {
+                    param([string]$PlainText)
+                    return ConvertTo-SecureString -String $PlainText -AsPlainText -Force
+                }
+
+                function Initialize-SetToolsRepoScenarioMocks {
+                    param(
+                        [Parameter(Mandatory = $true)][string]$ToolsShortVersion,
+                        [Parameter(Mandatory = $true)][string]$HighestExistingVersion,
+                        [Parameter(Mandatory = $true)][bool]$VersionAlreadyExists
+                    )
+
+                    $script:toolsVersion = "vmtools-$ToolsShortVersion"
+                    $script:tempRoot = "C:\mock\newtools_test"
+                    $script:sourceDir = "$script:tempRoot\vmware\apps\vmtools\windows64\$script:toolsVersion"
+                    $script:topLevelSourceDir = "$script:tempRoot\vmware\apps\vmtools\windows64"
+                    $script:destPath = "DS:/GuestStore/vmware/apps/vmtools/windows64"
+                    $script:versionDestPath = "$script:destPath/$script:toolsVersion"
+                    $script:highestExistingVersion = $HighestExistingVersion
+                    $script:versionAlreadyExists = $VersionAlreadyExists
+
+                    # URL validation and download path are always mocked; no network access.
+                    Mock Invoke-WebRequest {
+                        if ($Method -eq 'Head') { return [PSCustomObject]@{ StatusCode = 200 } }
+                        return $null
+                    } -ModuleName Microsoft.AVS.Management
+
+                    Mock New-Item {
+                        [PSCustomObject]@{ FullName = $script:tempRoot; Name = 'newtools_test' }
+                    } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' -and $Path -match '^\.([\\/])newtools_' }
+
+                    Mock New-Item {
+                        [PSCustomObject]@{ FullName = $Path; Name = (Split-Path -Path $Path -Leaf) }
+                    } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' -and $Path -like 'DS:/*' }
+
+                    Mock Get-Item { [PSCustomObject]@{ Length = 4096 } } -ModuleName Microsoft.AVS.Management
+                    Mock Expand-Archive { } -ModuleName Microsoft.AVS.Management
+                    Mock Join-Path { "$Path/$ChildPath" } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Path -like 'DS:*' }
+
+                    Mock Test-Path {
+                        switch ($Path) {
+                            "$script:tempRoot/tools.zip" { return $true }
+                            $script:destPath { return $true }
+                            $script:versionDestPath { return $script:versionAlreadyExists }
+                            $script:topLevelSourceDir { return $false }
+                            default { return $true }
+                        }
+                    } -ModuleName Microsoft.AVS.Management
+
+                    Mock Get-ChildItem {
+                        # Locate extracted vmtools-* directory
+                        if ($Directory) {
+                            return @([PSCustomObject]@{ Name = $script:toolsVersion; FullName = $script:sourceDir })
+                        }
+
+                        # Existing datastore versions used to compute highestExistingVersion
+                        if ($Path -eq $script:destPath -and -not $Filter -and -not $Recurse -and -not $File) {
+                            return @([PSCustomObject]@{ Name = "vmtools-$script:highestExistingVersion"; FullName = "$script:destPath/vmtools-$script:highestExistingVersion" })
+                        }
+
+                        # Source metadata is present so update path is testable
+                        if ($Path -eq $script:sourceDir -and $Filter -eq 'metadata.json') {
+                            return @([PSCustomObject]@{ Name = 'metadata.json'; FullName = "$script:sourceDir\metadata.json" })
+                        }
+
+                        return @()
+                    } -ModuleName Microsoft.AVS.Management
+
+                    $script:browser = New-Object psobject
+                    Add-Member -InputObject $script:browser -MemberType ScriptMethod -Name SearchDatastore -Value {
+                        param($path, $spec)
+                        return [PSCustomObject]@{ File = @([PSCustomObject]@{ FriendlyName = 'GuestStore' }) }
+                    } -Force
+
+                    Mock Get-View { $script:browser } -ModuleName Microsoft.AVS.Management
+                    Mock New-Object {
+                        if ($TypeName -eq 'VMware.Vim.HostDatastoreBrowserSearchSpec') { return [PSCustomObject]@{ Query = @() } }
+                        if ($TypeName -eq 'VMware.Vim.FolderFileQuery') { return [PSCustomObject]@{} }
+                    } -ModuleName Microsoft.AVS.Management -ParameterFilter {
+                        $TypeName -eq 'VMware.Vim.HostDatastoreBrowserSearchSpec' -or $TypeName -eq 'VMware.Vim.FolderFileQuery'
+                    }
+
+                    Mock Get-Datastore {
+                        return @(
+                            [PSCustomObject]@{
+                                Name = 'vsanDatastore'
+                                Id = 'Datastore-ds-123'
+                                ExtensionData = [PSCustomObject]@{
+                                    Browser = 'browser-1'
+                                    Summary = [PSCustomObject]@{ Type = 'vsan'; Url = 'ds:///vmfs/volumes/vsanDatastore/' }
+                                }
+                            }
+                        )
+                    } -ModuleName Microsoft.AVS.Management
+
+                    Mock Get-PSDrive { $null } -ModuleName Microsoft.AVS.Management
+                    Mock New-PSDrive { [PSCustomObject]@{ Name = 'DS' } } -ModuleName Microsoft.AVS.Management
+                    Mock Remove-PSDrive { } -ModuleName Microsoft.AVS.Management
+
+                    Mock Get-VMHost {
+                        return @(
+                            [PSCustomObject]@{
+                                Name = 'esx1'
+                                ExtensionData = [PSCustomObject]@{ Datastore = [PSCustomObject]@{ value = @('ds-123') } }
+                            }
+                        )
+                    } -ModuleName Microsoft.AVS.Management
+
+                    $script:setObj = New-Object psobject
+                    Add-Member -InputObject $script:setObj -MemberType ScriptMethod -Name CreateArgs -Value { return [PSCustomObject]@{ url = $null } } -Force
+                    Add-Member -InputObject $script:setObj -MemberType ScriptMethod -Name invoke -Value { param($arguments) return $true } -Force
+                    $script:esxcli = [PSCustomObject]@{
+                        system = [PSCustomObject]@{
+                            settings = [PSCustomObject]@{
+                                gueststore = [PSCustomObject]@{
+                                    repository = [PSCustomObject]@{ set = $script:setObj }
+                                }
+                            }
+                        }
+                    }
+                    Mock Get-EsxCli { $script:esxcli } -ModuleName Microsoft.AVS.Management
+
+                    Mock Copy-DatastoreItem { } -ModuleName Microsoft.AVS.Management
+                }
+            }
+
+            It "Older version upload preserves top-level metadata.json" {
+                # Validates: when incoming version is older than existing highest, top-level metadata is not overwritten.
+                $IncomingVersion = '12.3.0'
+                $ExistingVersion = '12.4.0'
+                Initialize-SetToolsRepoScenarioMocks -ToolsShortVersion $IncomingVersion -HighestExistingVersion $ExistingVersion -VersionAlreadyExists $true
+                $secureUrl = ConvertTo-TestSecureString 'https://example.com/tools.zip'
+
+                { Set-ToolsRepo -ToolsURL $secureUrl } | Should -Not -Throw
+
+                Assert-MockCalled Copy-DatastoreItem -ModuleName Microsoft.AVS.Management -Times 0 -Exactly -Scope It -ParameterFilter {
+                    $Destination -like '*metadata.json'
+                }
+            }
+
+            It "Newer version upload updates top-level metadata.json" {
+                # Validates: when incoming version is newer than existing highest, top-level metadata update is performed once.
+                $IncomingVersion = '12.4.0'
+                $ExistingVersion = '12.3.0'
+                Initialize-SetToolsRepoScenarioMocks -ToolsShortVersion $IncomingVersion -HighestExistingVersion $ExistingVersion -VersionAlreadyExists $true
+                $secureUrl = ConvertTo-TestSecureString 'https://example.com/tools.zip'
+
+                { Set-ToolsRepo -ToolsURL $secureUrl } | Should -Not -Throw
+
+                Assert-MockCalled Copy-DatastoreItem -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -Scope It -ParameterFilter {
+                    $Destination -like '*metadata.json'
+                }
+            }
+
+            It "Version already exists skips copy and overwrite" {
+                # Validates: when target version folder already exists, no copy operation is performed.
+                $IncomingVersion = '12.4.0'
+                $ExistingVersion = '12.4.0'
+                Initialize-SetToolsRepoScenarioMocks -ToolsShortVersion $IncomingVersion -HighestExistingVersion $ExistingVersion -VersionAlreadyExists $true
+                $secureUrl = ConvertTo-TestSecureString 'https://example.com/tools.zip'
+
+                { Set-ToolsRepo -ToolsURL $secureUrl } | Should -Not -Throw
+
+                Assert-MockCalled Copy-DatastoreItem -ModuleName Microsoft.AVS.Management -Times 0 -Exactly -Scope It
             }
         }
     }
 
     Context "Error Handling" {
         It "Should wrap original error in descriptive message" {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
             Mock New-Item { throw "Permission denied" } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            
-            { Set-ToolsRepo -ToolsURL $secureUrl } | 
+
+            { Set-ToolsRepo -ToolsURL $secureUrl } |
                 Should -Throw -ExpectedMessage "*Failed to create temporary directory*Permission denied*"
         }
 
         It "Should re-throw after catching to propagate error" {
             Mock Invoke-WebRequest { throw "Network error" } -ModuleName Microsoft.AVS.Management
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            
+
             { Set-ToolsRepo -ToolsURL $secureUrl } | Should -Throw
         }
     }
 
     Context "PSDrive Cleanup" {
         It "Should attempt PSDrive cleanup even when datastore processing fails" {
-            Mock Invoke-WebRequest { 
-                [PSCustomObject]@{ StatusCode = 200 } 
+            $IncomingVersion = '12.3.0'
+            Mock Invoke-WebRequest {
+                [PSCustomObject]@{ StatusCode = 200 }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Method -eq 'Head' }
-            Mock New-Item { 
-                [PSCustomObject]@{ FullName = "/tmp/newtools_test" } 
+            Mock New-Item {
+                [PSCustomObject]@{ FullName = "/tmp/newtools_test" }
             } -ModuleName Microsoft.AVS.Management -ParameterFilter { $ItemType -eq 'Directory' }
             Mock Invoke-WebRequest { } -ModuleName Microsoft.AVS.Management -ParameterFilter { $OutFile }
             Mock Test-Path { $true } -ModuleName Microsoft.AVS.Management
             Mock Get-Item { [PSCustomObject]@{ Length = 1024 } } -ModuleName Microsoft.AVS.Management
             Mock Expand-Archive { } -ModuleName Microsoft.AVS.Management
-            Mock Get-ChildItem { [PSCustomObject]@{ Name = "vmtools-12.3.0" } } -ModuleName Microsoft.AVS.Management
-            Mock Get-Datastore { 
-                [PSCustomObject]@{ 
+            Mock Get-ChildItem { [PSCustomObject]@{ Name = "vmtools-$IncomingVersion" } } -ModuleName Microsoft.AVS.Management
+            Mock Get-Datastore {
+                [PSCustomObject]@{
                     Name = "vsanDatastore"
                     extensionData = [PSCustomObject]@{ Summary = [PSCustomObject]@{ Type = 'vsan' } }
-                } 
+                }
             } -ModuleName Microsoft.AVS.Management
             Mock Get-PSDrive { $true } -ModuleName Microsoft.AVS.Management
             Mock Remove-PSDrive { } -ModuleName Microsoft.AVS.Management
             Mock New-PSDrive { throw "PSDrive creation failed" } -ModuleName Microsoft.AVS.Management -ParameterFilter { $Name -eq 'DS' }
-            
+
             $secureUrl = ConvertTo-TestSecureString "https://example.com/tools.zip"
-            
+
             try { Set-ToolsRepo -ToolsURL $secureUrl } catch { }
-            
+
             # Verify cleanup was attempted
             Should -Invoke Remove-PSDrive -ModuleName Microsoft.AVS.Management -ParameterFilter { $Name -eq 'DS' }
         }


### PR DESCRIPTION

This PR re-creates the previously approved changes from #375 using a personal branch in the Azure repository, as fork-based PRs do not run CI.

### Summary
This change updates the `Set-ToolsRepo` run command behavior to allow uploading older VM Tools versions **without modifying `metadata.json`**, while still preserving the latest version metadata.

### Changes
- Allows upload of older VM Tools versions without impacting `metadata.json`
- Ensures the latest version information remains intact
- Improves datastore browse path handling and validation logic
- Includes reviewer-requested fixes and refinements
- Adds unit tests covering the updated metadata behavior

### Validation
- Existing unit tests pass
- New unit tests added for metadata behavior
- Behavior verified to preserve latest VM Tools metadata

### Additional Changes
- Only check real VMware Tools version folders so other files don’t affect metadata updates.
- Fail the run command clearly if any host setup fails, instead of reporting partial success.
- Fix tests to correctly verify older version uploads without changing the main metadata file.
- Fixed test paths to use $TestDrive for Linux CI.
- Added proxy function to mock Get-EsxCli without PowerCLI type errors.
- Added PSIsContainer to mock objects so version comparison works correctly.
- Fixed assertion to match actual Copy-DatastoreItem destination.
- Set TEMP/TMP to $TestDrive so tests work cross-platform.
- Removed Classes.ps1 import that came in from merge, not part of this PR.

This PR replaces the earlier fork-based PR (#375) with the same functionality, following the recommended Azure repo workflow.


