### PR TITLE
Added friendly name output to Get‑UnassociatedVsanObjectsWithPolicy u…

### DIFF
--- a/Microsoft.AVS.Management/AVSvSANUtils.ps1
+++ b/Microsoft.AVS.Management/AVSvSANUtils.ps1
@@ -14,6 +14,48 @@
 
 #>
 
+# Helper that attempts to extract a friendly name from ext attrs JSON
+function Get-VsanFriendlyNameFromExtAttrs {
+    param(
+        [Parameter(Mandatory = $true)]
+        $ExtAttrsJson
+    )
+
+    # Common “name-like” fields that sometimes show up in vSAN ext attrs
+    $candidateKeys = @(
+        'friendlyName',
+        'FriendlyName',
+        'name',
+        'Name',
+        'objectName',
+        'ObjectName',
+        'vmName',
+        'VmName',
+        'path',
+        'Path',
+        'namespace',
+        'Namespace',
+        'filePath',
+        'FilePath',
+        'displayName',
+        'DisplayName'
+        )
+
+    foreach ($k in $candidateKeys) {
+        try {
+            # Works for both PSCustomObject (ConvertFrom-Json) and Hashtable-like shapes
+            if ($null -ne $ExtAttrsJson.PSObject.Properties[$k] -and
+                [string]::IsNullOrWhiteSpace([string]$ExtAttrsJson.$k) -eq $false) {
+                return [string]$ExtAttrsJson.$k
+            }
+         } catch {
+            # ignore and continue
+        }
+    }
+
+    return $null
+}
+
 Function New-AVSCommonStoragePolicy {
     <#
         .DESCRIPTION

--- a/Microsoft.AVS.Management/AVSvSANUtils.ps1
+++ b/Microsoft.AVS.Management/AVSvSANUtils.ps1
@@ -14,48 +14,6 @@
 
 #>
 
-# Helper that attempts to extract a friendly name from ext attrs JSON
-function Get-VsanFriendlyNameFromExtAttrs {
-    param(
-        [Parameter(Mandatory = $true)]
-        $ExtAttrsJson
-    )
-
-    # Common “name-like” fields that sometimes show up in vSAN ext attrs
-    $candidateKeys = @(
-        'friendlyName',
-        'FriendlyName',
-        'name',
-        'Name',
-        'objectName',
-        'ObjectName',
-        'vmName',
-        'VmName',
-        'path',
-        'Path',
-        'namespace',
-        'Namespace',
-        'filePath',
-        'FilePath',
-        'displayName',
-        'DisplayName'
-        )
-
-    foreach ($k in $candidateKeys) {
-        try {
-            # Works for both PSCustomObject (ConvertFrom-Json) and Hashtable-like shapes
-            if ($null -ne $ExtAttrsJson.PSObject.Properties[$k] -and
-                [string]::IsNullOrWhiteSpace([string]$ExtAttrsJson.$k) -eq $false) {
-                return [string]$ExtAttrsJson.$k
-            }
-         } catch {
-            # ignore and continue
-        }
-    }
-
-    return $null
-}
-
 Function New-AVSCommonStoragePolicy {
     <#
         .DESCRIPTION

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -210,7 +210,23 @@ function Get-UnassociatedVsanObjectsWithPolicy {
             $matchedObjects++
             try {
                 $jsonResult = ($vsanIntSys.GetVsanObjExtAttrs($obj.Uuid)) | ConvertFrom-Json
-                Write-Output $jsonResult
+                
+                # derive friendly name if present in ext attrs
+                $friendlyName = Get-VsanFriendlyNameFromExtAttrs -ExtAttrsJson $jsonResult
+                if ([string]::IsNullOrWhiteSpace($friendlyName)) {
+                    $friendlyName = '<not-available>'
+                }
+
+                # emit enriched object (still includes the raw ext attrs)
+                $output = [pscustomobject]@{
+                    Uuid         = $obj.Uuid
+                    PolicyName   = $obj.SpbmProfileName
+                    FriendlyName = $friendlyName
+                    ExtAttrs     = $jsonResult
+                }
+
+                Write-Output $output
+
             }
             catch {
                 Write-Warning "Failed to retrieve or parse attributes for object $($obj.Uuid): $_"

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -211,21 +211,31 @@ function Get-UnassociatedVsanObjectsWithPolicy {
             try {
                 $jsonResult = ($vsanIntSys.GetVsanObjExtAttrs($obj.Uuid)) | ConvertFrom-Json
                 
-                # derive friendly name if present in ext attrs
-                $friendlyName = Get-VsanFriendlyNameFromExtAttrs -ExtAttrsJson $jsonResult
-                if ([string]::IsNullOrWhiteSpace($friendlyName)) {
-                    $friendlyName = '<not-available>'
-                }
+                foreach ($object in $jsonResult | Get-Member) {
 
-                # emit enriched object (still includes the raw ext attrs)
-                $output = [pscustomobject]@{
-                    Uuid         = $obj.Uuid
-                    PolicyName   = $obj.SpbmProfileName
-                    FriendlyName = $friendlyName
-                    ExtAttrs     = $jsonResult
-                }
+                    if ($($object.Name) -ne "Equals" -and
+                        $($object.Name) -ne "GetHashCode" -and
+                        $($object.Name) -ne "GetType" -and
+                        $($object.Name) -ne "ToString") {
 
-                Write-Output $output
+                        $objectID = $object.Name
+
+                        if ($null -ne $jsonResult.$($objectID).'User friendly name') {
+                            $friendlyName = $jsonResult.$($objectID).'User friendly name'
+                        }
+                        else {
+                            $friendlyName = '<not-available>'
+                        }
+
+                        $output = [pscustomobject]@{
+                            Uuid         = $jsonResult.$($objectID).'UUID'
+                            PolicyName   = $obj.SpbmProfileName
+                            FriendlyName = $friendlyName
+                        }
+
+                        Write-Output $output
+                    }
+                }
 
             }
             catch {


### PR DESCRIPTION
…sing extAttrs parsing

This PR closes #

The changes in this PR are as follows:

This PR addresses a gap in the current Get‑UnassociatedVsanObjectsWithPolicy Run Command output where only UUIDs are returned for unassociated vSAN objects.
In customer troubleshooting and cleanup workflows, UUID‑only output makes it difficult to correlate unassociated objects to their originating virtual machines or namespaces, often requiring manual lookup through additional vSAN tools or backend commands before taking remediation actions such as policy updates or deletion.
This change updates the Run Command to retrieve and surface the User Friendly Name of unassociated vSAN objects from extended attributes (extAttrs), using the same logic currently employed by internal ShowUnassociatedObjects workflows. This ensures:

- Unassociated namespace objects are displayed with their corresponding VM or file name where available
- vdisk objects without a defined friendly name are explicitly marked as <not-available>

The existing UUID‑based identification and query logic remain unchanged to maintain backward compatibility with current deletion and policy update workflows that rely on UUIDs

Test Output:
<img width="1771" height="933" alt="image" src="https://github.com/user-attachments/assets/27d32b78-73bd-4cd1-a345-6453d0362799" />



I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

