### PR TITLE
Add Run Commands for IPv6 L3 Forwarding (Get/Enable/Disable)

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -12,7 +12,7 @@
     RootModule = 'Microsoft.AVS.Management.psm1'
     
     # Version number of this module.
-    ModuleVersion = '9.0.1'
+    ModuleVersion = '9.1.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -92,6 +92,9 @@
         'Update-StoragePolicyofUnassociatedvSANObjects'
         'Remove-AvsUnassociatedObject'
         'Get-EsxtopData'
+        'Get-AVSIPv6Status'
+        'Enable-AVSIPv6'
+        'Disable-AVSIPv6'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2226,7 +2226,8 @@ function Get-AVSIPv6Status {
 
     try {
         $response = Invoke-RestMethod -Uri $uri -Method Get `
-            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+            -Authentication Basic -Credential $NsxCredential `
+            -SkipCertificateCheck -ErrorAction Stop
 
         $mode = $response.l3_forwarding_mode
         Write-Host "Current L3 forwarding mode: $mode"
@@ -2271,7 +2272,8 @@ function Enable-AVSIPv6 {
     # Read current state before making changes
     try {
         $currentConfig = Invoke-RestMethod -Uri $uri -Method Get `
-            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+            -Authentication Basic -Credential $NsxCredential `
+            -SkipCertificateCheck -ErrorAction Stop
     }
     catch {
         throw "Failed to read current NSX global config at '$uri': $($_.Exception.Message)"
@@ -2287,8 +2289,8 @@ function Enable-AVSIPv6 {
     # Apply the change
     try {
         Invoke-RestMethod -Uri $uri -Method Patch -Body $body `
-            -ContentType 'application/json' -Credential $NsxCredential `
-            -SkipCertificateCheck -ErrorAction Stop | Out-Null
+            -ContentType 'application/json' -Authentication Basic `
+            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop | Out-Null
         Write-Host "PATCH request sent successfully."
     }
     catch {
@@ -2298,7 +2300,8 @@ function Enable-AVSIPv6 {
     # Verify the change
     try {
         $verify = Invoke-RestMethod -Uri $uri -Method Get `
-            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+            -Authentication Basic -Credential $NsxCredential `
+            -SkipCertificateCheck -ErrorAction Stop
     }
     catch {
         throw "IPv6 PATCH was sent but verification read failed at '$uri': $($_.Exception.Message)"
@@ -2345,7 +2348,8 @@ function Disable-AVSIPv6 {
     # Read current state before making changes
     try {
         $currentConfig = Invoke-RestMethod -Uri $uri -Method Get `
-            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+            -Authentication Basic -Credential $NsxCredential `
+            -SkipCertificateCheck -ErrorAction Stop
     }
     catch {
         throw "Failed to read current NSX global config at '$uri': $($_.Exception.Message)"
@@ -2361,8 +2365,8 @@ function Disable-AVSIPv6 {
     # Apply the change
     try {
         Invoke-RestMethod -Uri $uri -Method Patch -Body $body `
-            -ContentType 'application/json' -Credential $NsxCredential `
-            -SkipCertificateCheck -ErrorAction Stop | Out-Null
+            -ContentType 'application/json' -Authentication Basic `
+            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop | Out-Null
         Write-Host "PATCH request sent successfully."
     }
     catch {
@@ -2372,7 +2376,8 @@ function Disable-AVSIPv6 {
     # Verify the change
     try {
         $verify = Invoke-RestMethod -Uri $uri -Method Get `
-            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+            -Authentication Basic -Credential $NsxCredential `
+            -SkipCertificateCheck -ErrorAction Stop
     }
     catch {
         throw "IPv6 PATCH was sent but verification read failed at '$uri': $($_.Exception.Message)"

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -2196,3 +2196,193 @@ function Get-EsxtopData {
 
     Write-Host "Esxtop collection complete. $Iterations samples from $($vmHost.Name)."
 }
+
+function Get-AVSIPv6Status {
+    <#
+    .SYNOPSIS
+        Gets the current IPv6 L3 forwarding mode from NSX.
+
+    .DESCRIPTION
+        Queries the NSX Policy API connectivity-global-config endpoint
+        and returns the current l3_forwarding_mode setting (IPV4_ONLY or IPV4_AND_IPV6).
+
+    .PARAMETER NsxCredential
+        PSCredential for the NSX Manager admin account.
+
+    .EXAMPLE
+        Get-AVSIPv6Status -NsxCredential $cred
+    #>
+    [CmdletBinding()]
+    [AVSAttribute(10, UpdatesSDDC = $false)]
+    param(
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'PSCredential for NSX Manager admin account.')]
+        [PSCredential]$NsxCredential
+    )
+
+    $nsxHost = "nsx.$SddcDnsSuffix"
+    $uri = "https://$nsxHost/policy/api/v1/infra/connectivity-global-config"
+
+    try {
+        $response = Invoke-RestMethod -Uri $uri -Method Get `
+            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+
+        $mode = $response.l3_forwarding_mode
+        Write-Host "Current L3 forwarding mode: $mode"
+
+        $NamedOutputs = @{ 'l3_forwarding_mode' = $mode }
+        Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+    }
+    catch {
+        throw "Failed to get IPv6 status from NSX at '$uri': $($_.Exception.Message)"
+    }
+}
+
+function Enable-AVSIPv6 {
+    <#
+    .SYNOPSIS
+        Enables IPv6 by setting NSX L3 forwarding mode to IPV4_AND_IPV6.
+
+    .DESCRIPTION
+        Patches the NSX Policy API connectivity-global-config endpoint to set
+        l3_forwarding_mode to IPV4_AND_IPV6, then verifies the change by reading
+        the configuration back.
+
+    .PARAMETER NsxCredential
+        PSCredential for the NSX Manager admin account.
+
+    .EXAMPLE
+        Enable-AVSIPv6 -NsxCredential $cred
+    #>
+    [CmdletBinding()]
+    [AVSAttribute(30, UpdatesSDDC = $true)]
+    param(
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'PSCredential for NSX Manager admin account.')]
+        [PSCredential]$NsxCredential
+    )
+
+    $nsxHost = "nsx.$SddcDnsSuffix"
+    $uri = "https://$nsxHost/policy/api/v1/infra/connectivity-global-config"
+    $body = @{ l3_forwarding_mode = 'IPV4_AND_IPV6' } | ConvertTo-Json
+
+    # Read current state before making changes
+    try {
+        $currentConfig = Invoke-RestMethod -Uri $uri -Method Get `
+            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+    }
+    catch {
+        throw "Failed to read current NSX global config at '$uri': $($_.Exception.Message)"
+    }
+
+    if ($currentConfig.l3_forwarding_mode -eq 'IPV4_AND_IPV6') {
+        Write-Host "IPv6 is already enabled. L3 forwarding mode: IPV4_AND_IPV6"
+        $NamedOutputs = @{ 'l3_forwarding_mode' = 'IPV4_AND_IPV6' }
+        Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+        return
+    }
+
+    # Apply the change
+    try {
+        Invoke-RestMethod -Uri $uri -Method Patch -Body $body `
+            -ContentType 'application/json' -Credential $NsxCredential `
+            -SkipCertificateCheck -ErrorAction Stop | Out-Null
+        Write-Host "PATCH request sent successfully."
+    }
+    catch {
+        throw "Failed to enable IPv6 on NSX at '$uri': $($_.Exception.Message)"
+    }
+
+    # Verify the change
+    try {
+        $verify = Invoke-RestMethod -Uri $uri -Method Get `
+            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+    }
+    catch {
+        throw "IPv6 PATCH was sent but verification read failed at '$uri': $($_.Exception.Message)"
+    }
+
+    if ($verify.l3_forwarding_mode -ne 'IPV4_AND_IPV6') {
+        throw "Verification failed. Expected 'IPV4_AND_IPV6' but got '$($verify.l3_forwarding_mode)'."
+    }
+
+    Write-Host "IPv6 enabled successfully. L3 forwarding mode: $($verify.l3_forwarding_mode)"
+    $NamedOutputs = @{ 'l3_forwarding_mode' = $verify.l3_forwarding_mode }
+    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+}
+
+function Disable-AVSIPv6 {
+    <#
+    .SYNOPSIS
+        Disables IPv6 by setting NSX L3 forwarding mode to IPV4_ONLY.
+
+    .DESCRIPTION
+        Patches the NSX Policy API connectivity-global-config endpoint to set
+        l3_forwarding_mode to IPV4_ONLY, then verifies the change by reading
+        the configuration back.
+
+    .PARAMETER NsxCredential
+        PSCredential for the NSX Manager admin account.
+
+    .EXAMPLE
+        Disable-AVSIPv6 -NsxCredential $cred
+    #>
+    [CmdletBinding()]
+    [AVSAttribute(30, UpdatesSDDC = $true)]
+    param(
+        [Parameter(
+            Mandatory = $true,
+            HelpMessage = 'PSCredential for NSX Manager admin account.')]
+        [PSCredential]$NsxCredential
+    )
+
+    $nsxHost = "nsx.$SddcDnsSuffix"
+    $uri = "https://$nsxHost/policy/api/v1/infra/connectivity-global-config"
+    $body = @{ l3_forwarding_mode = 'IPV4_ONLY' } | ConvertTo-Json
+
+    # Read current state before making changes
+    try {
+        $currentConfig = Invoke-RestMethod -Uri $uri -Method Get `
+            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+    }
+    catch {
+        throw "Failed to read current NSX global config at '$uri': $($_.Exception.Message)"
+    }
+
+    if ($currentConfig.l3_forwarding_mode -eq 'IPV4_ONLY') {
+        Write-Host "IPv6 is already disabled. L3 forwarding mode: IPV4_ONLY"
+        $NamedOutputs = @{ 'l3_forwarding_mode' = 'IPV4_ONLY' }
+        Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+        return
+    }
+
+    # Apply the change
+    try {
+        Invoke-RestMethod -Uri $uri -Method Patch -Body $body `
+            -ContentType 'application/json' -Credential $NsxCredential `
+            -SkipCertificateCheck -ErrorAction Stop | Out-Null
+        Write-Host "PATCH request sent successfully."
+    }
+    catch {
+        throw "Failed to disable IPv6 on NSX at '$uri': $($_.Exception.Message)"
+    }
+
+    # Verify the change
+    try {
+        $verify = Invoke-RestMethod -Uri $uri -Method Get `
+            -Credential $NsxCredential -SkipCertificateCheck -ErrorAction Stop
+    }
+    catch {
+        throw "IPv6 PATCH was sent but verification read failed at '$uri': $($_.Exception.Message)"
+    }
+
+    if ($verify.l3_forwarding_mode -ne 'IPV4_ONLY') {
+        throw "Verification failed. Expected 'IPV4_ONLY' but got '$($verify.l3_forwarding_mode)'."
+    }
+
+    Write-Host "IPv6 disabled successfully. L3 forwarding mode: $($verify.l3_forwarding_mode)"
+    $NamedOutputs = @{ 'l3_forwarding_mode' = $verify.l3_forwarding_mode }
+    Set-Variable -Name NamedOutputs -Value $NamedOutputs -Scope Global
+}

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -1590,11 +1590,11 @@ Describe "Enable-AVSIPv6" {
 
     Context "Successful Enable" {
         It "Should PATCH and verify when enabling IPv6" {
-            $invokeCount = 0
+            $script:enableInvokeCount = 0
             Mock Invoke-RestMethod {
                 param($Uri, $Method, $Body, $ContentType, $Credential, [switch]$SkipCertificateCheck)
-                $invokeCount++
-                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                $script:enableInvokeCount++
+                if ($Method -eq 'Get' -and $script:enableInvokeCount -eq 1) {
                     return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
                 }
                 if ($Method -eq 'Patch') {
@@ -1722,11 +1722,11 @@ Describe "Disable-AVSIPv6" {
 
     Context "Successful Disable" {
         It "Should PATCH and verify when disabling IPv6" {
-            $invokeCount = 0
+            $script:disableInvokeCount = 0
             Mock Invoke-RestMethod {
                 param($Uri, $Method, $Body, $ContentType, $Credential, [switch]$SkipCertificateCheck)
-                $invokeCount++
-                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                $script:disableInvokeCount++
+                if ($Method -eq 'Get' -and $script:disableInvokeCount -eq 1) {
                     return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_AND_IPV6' }
                 }
                 if ($Method -eq 'Patch') {

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -1456,3 +1456,338 @@ Describe "Remove-AvsUnassociatedObject" {
         }
     }
 }
+
+Describe "Get-AVSIPv6Status" {
+    BeforeAll {
+        # Set the runtime variable the function depends on
+        $global:SddcDnsSuffix = "sddc.test.local"
+
+        function New-TestCredential {
+            $secPass = ConvertTo-SecureString 'TestPass123!' -AsPlainText -Force
+            return [PSCredential]::new('admin', $secPass)
+        }
+    }
+
+    AfterAll {
+        Remove-Variable -Name SddcDnsSuffix -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    Context "Parameter Validation" {
+        It "Should have NsxCredential as mandatory parameter" {
+            $cmd = Get-Command Get-AVSIPv6Status
+            $param = $cmd.Parameters['NsxCredential']
+            $param.Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
+        }
+
+        It "Should have NsxCredential parameter of type PSCredential" {
+            $cmd = Get-Command Get-AVSIPv6Status
+            $cmd.Parameters['NsxCredential'].ParameterType.Name | Should -Be 'PSCredential'
+        }
+
+        It "Should have AVSAttribute with 10 minute timeout" {
+            $cmd = Get-Command Get-AVSIPv6Status
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr | Should -Not -BeNullOrEmpty
+            $avsAttr.Timeout.TotalMinutes | Should -Be 10
+        }
+
+        It "Should have AVSAttribute with UpdatesSDDC set to false" {
+            $cmd = Get-Command Get-AVSIPv6Status
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr.UpdatesSDDC | Should -Be $false
+        }
+    }
+
+    Context "Successful Query" {
+        It "Should return the current l3_forwarding_mode" {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
+            } -ModuleName Microsoft.AVS.Management
+            Mock Write-Host { } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Get-AVSIPv6Status -NsxCredential $cred } | Should -Not -Throw
+
+            Should -Invoke Invoke-RestMethod -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -ParameterFilter {
+                $Uri -eq 'https://nsx.sddc.test.local/policy/api/v1/infra/connectivity-global-config' -and
+                $Method -eq 'Get'
+            }
+        }
+    }
+
+    Context "Error Handling" {
+        It "Should throw when NSX API call fails" {
+            Mock Invoke-RestMethod { throw "Connection refused" } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Get-AVSIPv6Status -NsxCredential $cred } |
+                Should -Throw -ExpectedMessage "*Failed to get IPv6 status from NSX*"
+        }
+    }
+}
+
+Describe "Enable-AVSIPv6" {
+    BeforeAll {
+        $global:SddcDnsSuffix = "sddc.test.local"
+
+        function New-TestCredential {
+            $secPass = ConvertTo-SecureString 'TestPass123!' -AsPlainText -Force
+            return [PSCredential]::new('admin', $secPass)
+        }
+    }
+
+    AfterAll {
+        Remove-Variable -Name SddcDnsSuffix -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    Context "Parameter Validation" {
+        It "Should have NsxCredential as mandatory parameter" {
+            $cmd = Get-Command Enable-AVSIPv6
+            $param = $cmd.Parameters['NsxCredential']
+            $param.Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
+        }
+
+        It "Should have NsxCredential parameter of type PSCredential" {
+            $cmd = Get-Command Enable-AVSIPv6
+            $cmd.Parameters['NsxCredential'].ParameterType.Name | Should -Be 'PSCredential'
+        }
+
+        It "Should have AVSAttribute with 30 minute timeout" {
+            $cmd = Get-Command Enable-AVSIPv6
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr | Should -Not -BeNullOrEmpty
+            $avsAttr.Timeout.TotalMinutes | Should -Be 30
+        }
+
+        It "Should have AVSAttribute with UpdatesSDDC set to true" {
+            $cmd = Get-Command Enable-AVSIPv6
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr.UpdatesSDDC | Should -Be $true
+        }
+    }
+
+    Context "Already Enabled" {
+        It "Should return early when IPv6 is already enabled" {
+            $callCount = 0
+            Mock Invoke-RestMethod {
+                $callCount++
+                [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_AND_IPV6' }
+            } -ModuleName Microsoft.AVS.Management
+            Mock Write-Host { } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Enable-AVSIPv6 -NsxCredential $cred } | Should -Not -Throw
+
+            # Should only call GET (read current state), not PATCH
+            Should -Invoke Invoke-RestMethod -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'Get'
+            }
+            Should -Invoke Invoke-RestMethod -ModuleName Microsoft.AVS.Management -Times 0 -Exactly -ParameterFilter {
+                $Method -eq 'Patch'
+            }
+        }
+    }
+
+    Context "Successful Enable" {
+        It "Should PATCH and verify when enabling IPv6" {
+            $invokeCount = 0
+            Mock Invoke-RestMethod {
+                param($Uri, $Method, $Body, $ContentType, $Credential, [switch]$SkipCertificateCheck)
+                $invokeCount++
+                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                    return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
+                }
+                if ($Method -eq 'Patch') {
+                    return $null
+                }
+                # Verification GET
+                return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_AND_IPV6' }
+            } -ModuleName Microsoft.AVS.Management
+            Mock Write-Host { } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Enable-AVSIPv6 -NsxCredential $cred } | Should -Not -Throw
+
+            Should -Invoke Invoke-RestMethod -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'Patch'
+            }
+        }
+    }
+
+    Context "Error Handling" {
+        It "Should throw when initial GET fails" {
+            Mock Invoke-RestMethod { throw "Connection refused" } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Enable-AVSIPv6 -NsxCredential $cred } |
+                Should -Throw -ExpectedMessage "*Failed to read current NSX global config*"
+        }
+
+        It "Should throw when PATCH fails" {
+            $invokeCount = 0
+            Mock Invoke-RestMethod {
+                param($Uri, $Method)
+                $invokeCount++
+                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                    return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
+                }
+                throw "403 Forbidden"
+            } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Enable-AVSIPv6 -NsxCredential $cred } |
+                Should -Throw -ExpectedMessage "*Failed to enable IPv6 on NSX*"
+        }
+
+        It "Should throw when verification shows wrong mode" {
+            $invokeCount = 0
+            Mock Invoke-RestMethod {
+                param($Uri, $Method)
+                $invokeCount++
+                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                    return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
+                }
+                if ($Method -eq 'Patch') {
+                    return $null
+                }
+                return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
+            } -ModuleName Microsoft.AVS.Management
+            Mock Write-Host { } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Enable-AVSIPv6 -NsxCredential $cred } |
+                Should -Throw -ExpectedMessage "*Verification failed*"
+        }
+    }
+}
+
+Describe "Disable-AVSIPv6" {
+    BeforeAll {
+        $global:SddcDnsSuffix = "sddc.test.local"
+
+        function New-TestCredential {
+            $secPass = ConvertTo-SecureString 'TestPass123!' -AsPlainText -Force
+            return [PSCredential]::new('admin', $secPass)
+        }
+    }
+
+    AfterAll {
+        Remove-Variable -Name SddcDnsSuffix -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    Context "Parameter Validation" {
+        It "Should have NsxCredential as mandatory parameter" {
+            $cmd = Get-Command Disable-AVSIPv6
+            $param = $cmd.Parameters['NsxCredential']
+            $param.Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Contain $true
+        }
+
+        It "Should have NsxCredential parameter of type PSCredential" {
+            $cmd = Get-Command Disable-AVSIPv6
+            $cmd.Parameters['NsxCredential'].ParameterType.Name | Should -Be 'PSCredential'
+        }
+
+        It "Should have AVSAttribute with 30 minute timeout" {
+            $cmd = Get-Command Disable-AVSIPv6
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr | Should -Not -BeNullOrEmpty
+            $avsAttr.Timeout.TotalMinutes | Should -Be 30
+        }
+
+        It "Should have AVSAttribute with UpdatesSDDC set to true" {
+            $cmd = Get-Command Disable-AVSIPv6
+            $avsAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_.TypeId.Name -eq 'AVSAttribute' }
+            $avsAttr.UpdatesSDDC | Should -Be $true
+        }
+    }
+
+    Context "Already Disabled" {
+        It "Should return early when IPv6 is already disabled" {
+            Mock Invoke-RestMethod {
+                [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
+            } -ModuleName Microsoft.AVS.Management
+            Mock Write-Host { } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Disable-AVSIPv6 -NsxCredential $cred } | Should -Not -Throw
+
+            Should -Invoke Invoke-RestMethod -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'Get'
+            }
+            Should -Invoke Invoke-RestMethod -ModuleName Microsoft.AVS.Management -Times 0 -Exactly -ParameterFilter {
+                $Method -eq 'Patch'
+            }
+        }
+    }
+
+    Context "Successful Disable" {
+        It "Should PATCH and verify when disabling IPv6" {
+            $invokeCount = 0
+            Mock Invoke-RestMethod {
+                param($Uri, $Method, $Body, $ContentType, $Credential, [switch]$SkipCertificateCheck)
+                $invokeCount++
+                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                    return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_AND_IPV6' }
+                }
+                if ($Method -eq 'Patch') {
+                    return $null
+                }
+                return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_ONLY' }
+            } -ModuleName Microsoft.AVS.Management
+            Mock Write-Host { } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Disable-AVSIPv6 -NsxCredential $cred } | Should -Not -Throw
+
+            Should -Invoke Invoke-RestMethod -ModuleName Microsoft.AVS.Management -Times 1 -Exactly -ParameterFilter {
+                $Method -eq 'Patch'
+            }
+        }
+    }
+
+    Context "Error Handling" {
+        It "Should throw when initial GET fails" {
+            Mock Invoke-RestMethod { throw "Connection refused" } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Disable-AVSIPv6 -NsxCredential $cred } |
+                Should -Throw -ExpectedMessage "*Failed to read current NSX global config*"
+        }
+
+        It "Should throw when PATCH fails" {
+            $invokeCount = 0
+            Mock Invoke-RestMethod {
+                param($Uri, $Method)
+                $invokeCount++
+                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                    return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_AND_IPV6' }
+                }
+                throw "403 Forbidden"
+            } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Disable-AVSIPv6 -NsxCredential $cred } |
+                Should -Throw -ExpectedMessage "*Failed to disable IPv6 on NSX*"
+        }
+
+        It "Should throw when verification shows wrong mode" {
+            $invokeCount = 0
+            Mock Invoke-RestMethod {
+                param($Uri, $Method)
+                $invokeCount++
+                if ($Method -eq 'Get' -and $invokeCount -eq 1) {
+                    return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_AND_IPV6' }
+                }
+                if ($Method -eq 'Patch') {
+                    return $null
+                }
+                return [PSCustomObject]@{ l3_forwarding_mode = 'IPV4_AND_IPV6' }
+            } -ModuleName Microsoft.AVS.Management
+            Mock Write-Host { } -ModuleName Microsoft.AVS.Management
+
+            $cred = New-TestCredential
+            { Disable-AVSIPv6 -NsxCredential $cred } |
+                Should -Throw -ExpectedMessage "*Verification failed*"
+        }
+    }
+}


### PR DESCRIPTION
The changes in this PR are as follows:

* Added `Get-AVSIPv6Status` — queries the NSX Policy API `connectivity-global-config` endpoint and returns the current `l3_forwarding_mode` (IPV4_ONLY or IPV4_AND_IPV6). Read-only, 10-min timeout.
* Added `Enable-AVSIPv6` — patches the NSX global config to set `l3_forwarding_mode` to `IPV4_AND_IPV6`, with pre-check (idempotent) and post-verification. 30-min timeout, UpdatesSDDC.
* Added `Disable-AVSIPv6` — patches the NSX global config to set `l3_forwarding_mode` to `IPV4_ONLY`, with pre-check (idempotent) and post-verification. 30-min timeout, UpdatesSDDC.
* All three functions exported in the module manifest.
* Added comprehensive Pester tests (parameter validation, AVSAttribute checks, idempotency, success paths, error handling).

## Test Plan

### Unit Tests (Pester — automated)
| # | Scenario | Covered |
|---|----------|---------|
| 1 | `Get-AVSIPv6Status` — parameter type & mandatory checks | ✅ |
| 2 | `Get-AVSIPv6Status` — AVSAttribute timeout (10 min) and UpdatesSDDC=false | ✅ |
| 3 | `Get-AVSIPv6Status` — successful GET returns mode via NamedOutputs | ✅ |
| 4 | `Get-AVSIPv6Status` — throws on API failure | ✅ |
| 5 | `Enable-AVSIPv6` — AVSAttribute timeout (30 min), UpdatesSDDC=true | ✅ |
| 6 | `Enable-AVSIPv6` — returns early when already IPV4_AND_IPV6 | ✅ |
| 7 | `Enable-AVSIPv6` — PATCH + verification on success | ✅ |
| 8 | `Enable-AVSIPv6` — throws on initial GET failure | ✅ |
| 9 | `Enable-AVSIPv6` — throws on PATCH failure | ✅ |
| 10 | `Enable-AVSIPv6` — throws on verification mismatch | ✅ |
| 11 | `Disable-AVSIPv6` — AVSAttribute timeout (30 min), UpdatesSDDC=true | ✅ |
| 12 | `Disable-AVSIPv6` — returns early when already IPV4_ONLY | ✅ |
| 13 | `Disable-AVSIPv6` — PATCH + verification on success | ✅ |
| 14 | `Disable-AVSIPv6` — throws on initial GET failure | ✅ |
| 15 | `Disable-AVSIPv6` — throws on PATCH failure | ✅ |
| 16 | `Disable-AVSIPv6` — throws on verification mismatch | ✅ |

### Manual E2E Tests (against SDDC)
| # | Test Case | Steps | Expected Result |
|---|-----------|-------|-----------------|
| 1 | Get status (baseline) | Run `Get-AVSIPv6Status -NsxCredential $cred` | Returns current `l3_forwarding_mode` in NamedOutputs |
| 2 | Enable IPv6 | Run `Enable-AVSIPv6 -NsxCredential $cred` | Mode changes to `IPV4_AND_IPV6`; confirmed via verification read |
| 3 | Enable IPv6 (idempotent) | Run `Enable-AVSIPv6` again | Returns early with "already enabled" message |
| 4 | Verify via Get | Run `Get-AVSIPv6Status` | Confirms `IPV4_AND_IPV6` |
| 5 | Disable IPv6 | Run `Disable-AVSIPv6 -NsxCredential $cred` | Mode changes to `IPV4_ONLY`; confirmed via verification read |
| 6 | Disable IPv6 (idempotent) | Run `Disable-AVSIPv6` again | Returns early with "already disabled" message |
| 7 | Verify via Get | Run `Get-AVSIPv6Status` | Confirms `IPV4_ONLY` |
| 8 | Invalid credentials | Run any function with bad `$cred` | Throws descriptive error with URI context |

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.
