### PR TITLE
Enhance skip output with clear, customer-friendly reasons and matched…

### DIFF
--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psm1
@@ -73,19 +73,46 @@ function Remove-AvsUnassociatedObject {
         }
 
         # Check if object is system-like
-        $isSystemLike = $fields | Where-Object { $_ -and $excludeRx.IsMatch($_) } | Measure-Object | Select-Object -Expand Count
-        $isSystemLike = $isSystemLike -gt 0
+        $systemMatches = @()
+        foreach ($f in $fields) {
+            if ($f -and $excludeRx.IsMatch($f)) {
+                $systemMatches += $f
+            }
+        }
+        $systemMatches = $systemMatches | Sort-Object -Unique
+        $isSystemLike = $systemMatches.Count -gt 0
 
         $hi = Get-HealthFromExt -Ext $ext
 
-        $safe = (-not $inMgmt) -and (-not $isSystemLike) -and (-not $hi.IsAbsent) -and (-not $hi.IsDegraded)
+        # Build explicit skip reasons for better customer visibility
+        $skipReasons = @()
 
-        if (-not $safe) {
-            Write-Warning "Skipping $($id.Uuid) → InMgmt=$inMgmt SystemLike=$isSystemLike Health=$($hi.HealthState)"
-            continue
+        if ($inMgmt) {
+            $skipReasons += "Object is associated with AVS management resources (management VMs or resource pools), so deletion is blocked"
         }
 
+        if ($isSystemLike) {
+            $skipReasons += "Object was not deleted because it appears to be related to protected AVS/vSAN infrastructure based on object metadata. Matched metadata value(s): $($systemMatches -join '; ')"
+        }
 
+        if ($hi.IsAbsent) {
+            $skipReasons += "Object health is Absent (data may not be fully available)"
+        }
+
+        if ($hi.IsDegraded) {
+            $skipReasons += "Object health is Degraded (object is not in a healthy state)"
+        }
+
+        $safe = $skipReasons.Count -eq 0
+
+        if (-not $safe) {
+            Write-Warning "Skipping $($id.Uuid)"
+            Write-Warning "Object Name: $($(if ($id.Name) { $id.Name } else { 'N/A' }))"
+            Write-Warning "Reason: $($skipReasons -join ' | ')"
+            Write-Warning "Details: UUID=$($id.Uuid); InMgmt=$inMgmt; SystemLike=$isSystemLike; Health=$($hi.HealthState); PolicyCompliance=$($hi.PolicyCompliance)"
+            Write-Warning "Action: Object not deleted due to AVS safety checks."
+            continue
+        }
 
         try {
             [void]$vsanIntSys.DeleteVsanObjects(@($id.Uuid), $true)


### PR DESCRIPTION
… metadata details for Remove-AvsUnassociatedObjec Run command
This PR improves the output of the run command to clearly indicate why a vSAN object is skipped during deletion, making it easier for customers to understand the decision.

This PR closes #

The changes in this PR are as follows:

Added explicit, customer-friendly skip reasons for blocked deletions (management association, system metadata match, health state)
Included matched metadata values when identifying system-related objects
Improved warning output with object name, detailed context, and action summary
Deduplicated system metadata matches for cleaner output
No changes to existing deletion or validation logic

Output(Tested with mgmt vm object UUID):
<img width="1918" height="352" alt="image" src="https://github.com/user-attachments/assets/1d081754-aadd-4d20-81f8-1cfab08d76cb" />


I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [x] **Formatted the code** using VSCode default formatter for PowerShell.
* [x] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

