### PR TITLE
use correct last prerelease suffix

### DIFF
--- a/.ci/templates/common-preview-build-stages.yml
+++ b/.ci/templates/common-preview-build-stages.yml
@@ -78,7 +78,7 @@ stages:
 
     - pwsh: |
         $env:PSModulePath = "$(System.DefaultWorkingDirectory):$env:PSModulePath"
-        echo "+ ${{ parameters.moduleFolderName }}@$(moduleVersion)-dev" > shuttle/baseline
+        echo "+ ${{ parameters.moduleFolderName }}@$(moduleVersion)-preview" > shuttle/baseline
         shuttle/shuttle generate
       env:
         METADATA: $(metadataAuthority)/$(metadataProject)/_artifacts/feed/$(metadataFeed)


### PR DESCRIPTION
This PR fixes the prerelease suffix used by preview pipeline to match the new shuttle expectations.