### PR TITLE
CDR registration fallback for broken PSGallery upstream

### DIFF
--- a/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psm1
+++ b/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psm1
@@ -251,7 +251,137 @@ function Get-MergedRedirectMap {
 
 <#
 .SYNOPSIS
+    Fallback module lookup via NuGet v3 registration endpoint when Find-PSResource fails.
+.DESCRIPTION
+    When the NuGet search endpoint is broken (e.g. upstream PSGallery returning 500s),
+    Find-PSResource returns nothing even for cached packages. This function queries the
+    NuGet v3 registration endpoint directly, which serves cached metadata without
+    hitting upstream sources.
+.OUTPUTS
+    PSCustomObject with Name, Version, Dependencies, Repository — or $null on failure.
+#>
+function Find-PSResourceViaRegistration {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Repository,
+
+        [Parameter(Mandatory = $false)]
+        [PSCredential]$Credential
+    )
+
+    try {
+        $repo = Get-PSResourceRepository -Name $Repository -ErrorAction Stop
+        $repoUri = $repo.Uri.ToString()
+
+        # Derive v3 service index URL
+        if ($repoUri -like '*/v3/index.json') {
+            $indexUrl = $repoUri
+        } elseif ($repoUri -like '*/v2') {
+            $indexUrl = $repoUri.Replace('/v2', '/v3/index.json')
+        } else {
+            Write-Verbose "Cannot derive v3 index URL from $repoUri"
+            return $null
+        }
+
+        # Build auth headers (ADO feeds use Basic auth with PSCredential)
+        $headers = @{}
+        if ($Credential) {
+            $username = $Credential.UserName
+            $password = $Credential.GetNetworkCredential().Password
+            $bytes = [System.Text.Encoding]::ASCII.GetBytes("${username}:${password}")
+            $headers['Authorization'] = "Basic $([Convert]::ToBase64String($bytes))"
+        }
+
+        # Discover registration base URL from NuGet v3 service index
+        $serviceIndex = Invoke-RestMethod -Uri $indexUrl -Headers $headers -TimeoutSec 15 -ErrorAction Stop
+        $registrationResource = $serviceIndex.resources |
+            Where-Object { $_.'@type' -like 'RegistrationsBaseUrl*' } |
+            Sort-Object { if ($_.'@type' -match 'Versioned') { 1 } else { 0 } } |
+            Select-Object -First 1
+
+        if (-not $registrationResource) {
+            Write-Verbose "No RegistrationsBaseUrl found in service index"
+            return $null
+        }
+
+        $registrationBase = $registrationResource.'@id'.TrimEnd('/')
+        $packageId = $Name.ToLowerInvariant()
+        $registrationUrl = "${registrationBase}/${packageId}/index.json"
+
+        Write-Verbose "Registration fallback: querying $registrationUrl"
+        $registration = Invoke-RestMethod -Uri $registrationUrl -Headers $headers -TimeoutSec 15 -ErrorAction Stop
+
+        # Search through registration pages for the target version
+        $catalogEntry = $null
+        foreach ($page in $registration.items) {
+            $pageItems = $page.items
+            # Pages may not inline items — fetch if needed
+            if (-not $pageItems -and $page.'@id') {
+                try {
+                    $pageData = Invoke-RestMethod -Uri $page.'@id' -Headers $headers -TimeoutSec 15 -ErrorAction Stop
+                    $pageItems = $pageData.items
+                } catch {
+                    Write-Verbose "Failed to fetch registration page: $($_.Exception.Message)"
+                    continue
+                }
+            }
+
+            if (-not $pageItems) { continue }
+
+            foreach ($item in $pageItems) {
+                $entry = $item.catalogEntry
+                if ($entry -and ($entry.version -eq $Version)) {
+                    $catalogEntry = $entry
+                    break
+                }
+            }
+            if ($catalogEntry) { break }
+        }
+
+        if (-not $catalogEntry) {
+            Write-Verbose "Version $Version not found in registration for $Name"
+            return $null
+        }
+
+        # Convert NuGet dependency groups to the shape expected by Build-RemoteDependencyGraph
+        $dependencies = @()
+        if ($catalogEntry.dependencyGroups) {
+            foreach ($group in $catalogEntry.dependencyGroups) {
+                if ($group.dependencies) {
+                    foreach ($dep in $group.dependencies) {
+                        $dependencies += [PSCustomObject]@{
+                            Name         = $dep.id
+                            VersionRange = $dep.range
+                        }
+                    }
+                }
+            }
+            $dependencies = $dependencies | Sort-Object Name -Unique
+        }
+
+        Write-Verbose "Registration fallback found $Name@$Version with $($dependencies.Count) dependencies"
+        return [PSCustomObject]@{
+            Name         = $Name
+            Version      = [version]($Version -replace '-.*$', '')
+            Dependencies = $dependencies
+            Repository   = $Repository
+        }
+    } catch {
+        Write-Verbose "Registration fallback failed for ${Name}@${Version}: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+<#
+.SYNOPSIS
     Builds a dependency graph by recursively querying a remote repository via Find-PSResource.
+    Falls back to NuGet v3 registration endpoint if Find-PSResource returns nothing.
 #>
 function Build-RemoteDependencyGraph {
     param(
@@ -305,6 +435,12 @@ function Build-RemoteDependencyGraph {
     
     Write-Verbose "Looking for dependencies: $ModuleName version $ModuleVersion"
     $moduleInfo = Find-PSResource @findParams -ErrorAction SilentlyContinue | Select-Object -First 1
+    
+    # Fallback: if search endpoint failed (e.g. broken upstream), try NuGet v3 registration directly
+    if (-not $moduleInfo -and $Repository) {
+        Write-Verbose "${indent}Find-PSResource returned nothing, trying NuGet v3 registration fallback..."
+        $moduleInfo = Find-PSResourceViaRegistration -Name $ModuleName -Version $ModuleVersion -Repository $Repository -Credential $Credential
+    }
     
     $notFound = $false
     if (-not $moduleInfo) {


### PR DESCRIPTION
This PR closes the PSGallery pipeline failure on build [163760087](https://msazure.visualstudio.com/One/_build/results?buildId=163760087) where `Microsoft.AVS.Storage` publish fails with `Module not found in repository: VMware.VimAutomation.Storage version 13.3.0.24145081`.
 
 The changes in this PR are as follows:
 
 * **Added `Find-PSResourceViaRegistration` fallback function** — when `Find-PSResource` returns nothing (due to the ADO feed's search endpoint failing from a broken PSGallery upstream), this queries the NuGet v3 registration endpoint directly, which serves cached package metadata without hitting the upstream. 
 * **Wired the fallback into `Build-RemoteDependencyGraph`** — after `Find-PSResource` returns no results and a repository is specified, the registration fallback activates automatically before marking a dependency as "not found".
 * **Root cause**: PSGallery has an ongoing Lucene search indexing issue (since Nov 2025, [status page](https://aka.ms/psgallery-status), [GitHub #345](https://github.com/PowerShell/PowerShellGallery/issues/345)). When their search returns 500s, the ADO 
feed's `query2/` endpoint times out for ALL packages — even those already cached locally. The registration endpoint (`registrations2/`) is unaffected.
 
 I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:
 
 * [x] **Formatted the code** using VSCode default formatter for PowerShell.
 * [ ] **Tested the code** end-to-end against an SDDC.
 * [x] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

Note: "Tested end-to-end against an SDDC" doesn't apply here — this is a build-tools change, not a cmdlet. I smoke-tested the fallback against the live avs-scripting-ps feed and it resolves VMware.VimAutomation.Storage@13.3.0.24145081 successfully while search is broken.