### PR TITLE
Fixed shuttle for prerelease version imports

### DIFF
--- a/.build-tools/publish.ps1
+++ b/.build-tools/publish.ps1
@@ -82,7 +82,7 @@ try {
     $isRemoteFeed = $previewFeed -match '^https?://'
     if ($isRemoteFeed) {
         Write-Output "Verifying installation of $moduleName@$version..."
-        Install-PSResourcePinned -Name $moduleName -RequiredVersion $version -Prerelease -Repository Preview -Credential $c
+        Install-PSResourcePinned -Name $moduleName -RequiredVersion $version -Prerelease -Force -Repository Preview -Credential $c
     } else {
         Write-Output "Verifying installation of $moduleName@$version (local folder, skipping dependencies)..."
         Install-PSResource -Name $moduleName -Version $version -Repository Preview -SkipDependencyCheck -TrustRepository

--- a/.ci/vars.yml
+++ b/.ci/vars.yml
@@ -14,7 +14,7 @@ variables:
   vmfsStageForSigningFolder: 'forSigningVmfs'
   nfsStageForUnsignedFolder: 'unsignedNfs'
   nfsStageForSigningFolder: 'forSigningNfs'
-  shuttleVersion: '1.10.17-76e1a542'
+  shuttleVersion: '1.10.18-289e7ea7'
   metadataAuthority: 'https://msazure.visualstudio.com'
   metadataProject: 'One'
   metadataFeed: 'avs-scripting-metadata'

--- a/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psm1
+++ b/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psm1
@@ -495,7 +495,7 @@ function Resolve-DiamondDependencies {
     foreach ($nodeKey in $Graph.Keys) {
         $node = $Graph[$nodeKey]
         if ($node.NotFound) {
-            throw "Module not found in repository: $($node.Name) version $($node.Version). No alternative version available to satisfy the dependency."
+            throw "Module not found: $($node.Name) version $($node.Version). No alternative version available to satisfy the dependency."
         }
     }
 }

--- a/tests/Microsoft.AVS.CDR.Tests.ps1
+++ b/tests/Microsoft.AVS.CDR.Tests.ps1
@@ -732,6 +732,48 @@ Describe "Import-ModulePinned" {
             Get-Module -Name $testModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
         }
     }
+
+    Context "Prerelease Version Handling" {
+        # Verify Import-ModulePinned can resolve and import an installed prerelease
+        # module when the caller passes the full prerelease version string
+        # (e.g. "1.0.0-preview"). Mocks Get-PSResource / Get-Module / Import-Module
+        # so the test runs without touching real package feeds.
+        It "Should import a module installed as prerelease when given the full prerelease version" {
+            InModuleScope Microsoft.AVS.CDR {
+                $modName = "TestPrereleaseModule"
+                $baseVersion = "1.0.0"
+                $prereleaseSuffix = "preview"
+                $fullVersion = "$baseVersion-$prereleaseSuffix"
+
+                # Mimic real Get-PSResource: -Version "1.0.0-preview" matches the
+                # installed prerelease; -Version "1.0.0" (release) does not.
+                Mock Get-PSResource {
+                    param($Name, $Version)
+                    if ($Name -ne $modName) { return $null }
+                    if ([string]::IsNullOrEmpty($Version) -or $Version -eq $fullVersion) {
+                        return [PSCustomObject]@{
+                            Name              = $modName
+                            Version           = [version]$baseVersion
+                            Prerelease        = $prereleaseSuffix
+                            InstalledLocation = "/tmp/modules"
+                            Dependencies      = @()
+                        }
+                    }
+                    return $null
+                }
+
+                Mock Get-Module { }
+                Mock Import-Module {
+                    param($Name, $RequiredVersion)
+                    [PSCustomObject]@{ Name = $Name; Version = [version]$RequiredVersion }
+                } -ParameterFilter { $Name -eq $modName }
+
+                { Import-ModulePinned -Name $modName -RequiredVersion $fullVersion } | Should -Not -Throw
+
+                Should -Invoke Import-Module -Times 1 -ParameterFilter { $Name -eq $modName }
+            }
+        }
+    }
 }
 
 Describe "Module Manifest" {


### PR DESCRIPTION
This PR 
- resolves the prerelease build issue with shuttle not being able to import;
- trims the misleading message (shared across install and import)
- adds a unit-test to make sure Import-ModulePinned accepts -prerelease versions

