### PR TITLE
Address scoping issue when importing via CDR

### DIFF
--- a/.ci/previewBuild.yml
+++ b/.ci/previewBuild.yml
@@ -19,9 +19,9 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
-  settings:
-    networkIsolationPolicy: Permissive,CFSClean
-    skipBuildTagsForGitHubPullRequests: true
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
+      skipBuildTagsForGitHubPullRequests: true
     featureFlags:
       autoBaseline: false
     sdl:

--- a/Microsoft.AVS.Management/Classes.ps1
+++ b/Microsoft.AVS.Management/Classes.ps1
@@ -18,12 +18,29 @@ AVSAttribute applied to a commandlet function indicates:
 - default timeout for the commandlet, maximum: 3h.
 - whether a commandlet is intended to be only for automation or is visible to all customers.
 AVS SDDC in Building state prevents other changes from being made to the SDDC until the function completes/fails.
+
+Defined via Add-Type (compiled C#) rather than the PowerShell `class` keyword so the
+resulting type is registered in the AppDomain and resolvable from any module scope —
+including dot-sourced .ps1 files inside consumer modules whose attribute-bind happens
+after Microsoft.AVS.Management's ScriptsToProcess has already run in a different
+SessionState (e.g., when Microsoft.AVS.CDR.Import-ModulePinned imports Management
+from inside its own module function). PowerShell `class` types are scoped to the
+declaring SessionState's type table and are not visible to dot-sourced consumers in
+that scenario.
 #>
-class AVSAttribute : Attribute {
-    [bool]$UpdatesSDDC = $false
-    [TimeSpan]$Timeout
-    [bool]$AutomationOnly = $false
-    AVSAttribute($timeoutMinutes) { $this.Timeout = New-TimeSpan -Minutes $timeoutMinutes }
+if (-not ('AVSAttribute' -as [type])) {
+    Add-Type -ErrorAction Stop -TypeDefinition @"
+using System;
+[AttributeUsage(AttributeTargets.All, AllowMultiple = false)]
+public sealed class AVSAttribute : Attribute {
+    public bool UpdatesSDDC { get; set; }
+    public bool AutomationOnly { get; set; }
+    public TimeSpan Timeout { get; private set; }
+    public AVSAttribute(double timeoutMinutes) {
+        this.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
+    }
+}
+"@
 }
 
 <#

--- a/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
+++ b/Microsoft.AVS.Management/Microsoft.AVS.Management.psd1
@@ -72,13 +72,7 @@
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
     # NestedModules = @()
     
-    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    # Storage / vSAN cmdlets (Set-VMStoragePolicy, Set-LocationStoragePolicy, Set-ClusterDefaultStoragePolicy,
-    # Get-StoragePolicies, Set-vSANCompressDedupe, New-AVSStoragePolicy, Remove-AVSStoragePolicy,
-    # Set-AVSVSANClusterUNMAPTRIM, Get-AVSVSANClusterUNMAPTRIM, Get-vSANDataInTransitEncryptionStatus,
-    # Set-vSANDataInTransitEncryption, Get-UnassociatedvSANObjectsWithPolicy,
-    # Update-StoragePolicyofUnassociatedvSANObjects, Remove-AvsUnassociatedObject) were moved to
-    # the Microsoft.AVS.Storage package as of v10.0.0.
+    # Functions to export from this module
     FunctionsToExport = @(
         'Set-ToolsRepo'
         'Set-CustomDRS'

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,31 @@ Import-ModulePinned -Name "VMware.PowerCLI" -RequiredVersion "13.3.0"
 
 CDR automatically loads the appropriate redirect map from its `maps/` directory based on the `Microsoft.AVS.Management` version in your dependency chain. You can also supply a custom redirect map via `-RedirectMapPath`.
 
+#### Transitional Guidance: Avoiding the `Import-ModulePinned` `AVSAttribute` Scope Bug
+
+Packages that still depend on `Microsoft.AVS.Management` **9 or earlier** are affected by a PowerShell scope-loss bug when imported via `Import-ModulePinned` and `Import-PSResourceDependencies`. The symptom is a parse-time error inside a dot-sourced script file in the consumer module:
+
+```
+Cannot find the type for custom attribute 'AVSAttribute'.
+Make sure that the assembly that contains this type is loaded.
+```
+
+Root cause: in those versions `AVSAttribute` is defined as a PowerShell `class` in `Classes.ps1` (run via `ScriptsToProcess`). When CDR's pinned-import functions call `Import-Module` from inside their own function body, that class registers into CDR's SessionState type table and is not visible to consumer scripts that dot-source `[AVSAttribute]`-decorated functions from sub-files. Functions decorated inline in the consumer's `.psm1` are unaffected; only dot-sourced files break.
+
+**Fix going forward**: starting with `Microsoft.AVS.Management` 10.0.250, `AVSAttribute` is defined via `Add-Type` and lives in the AppDomain — the bug cannot occur. Take the dependency to 10.0.250+ when possible.
+
+**Transitional pattern** for consumers that cannot yet upgrade to 10.0.250+: replace `Import-ModulePinned` / `Import-PSResourceDependencies` with `Find-PSResourcesPinned` + a caller-driven top-level `Import-Module` loop. Because the imports run at top-level scope (not inside a CDR function), `ScriptsToProcess` registers the PS-class into the runspace where consumers can resolve it. `Find-PSResourcesPinned` already returns dependencies in topological order, so a plain sequential `foreach` is sufficient — no extra ordering logic is required.
+
+```powershell
+# Transitional pattern (works regardless of Management version)
+$resolved = Find-PSResourcesPinned -Name 'VMware.VCDA.AVS' -RequiredVersion '1.0.5'
+foreach ($r in $resolved) {
+    Import-Module -Name $r.Name -RequiredVersion $r.Version -Global -DisableNameChecking -ErrorAction Stop
+}
+```
+
+Once the consumer's `Microsoft.AVS.Management` dependency is at 10.0.250 or later, `Import-ModulePinned` and `Import-PSResourceDependencies` can be used directly again — both code paths produce correct results, and the transitional pattern can be removed.
+
 ### 2.3 Versioning
 
 Follow [semver guidelines](https://semver.org/) when publishing. Supported version suffixes:


### PR DESCRIPTION
This PR addresses CDR (pinned import) shortcomings due PS inconsistencies wrt to class/type import:

* Provide short-term workaround documentation
* Change `AVSAttribute` class definition to work around the shortcomings

Also, separately fixes preview pipeline YAML whitespaces.

