### PR TITLE
Use Add-Type for AVSSecureFolder

### DIFF
--- a/Microsoft.AVS.Management/Classes.ps1
+++ b/Microsoft.AVS.Management/Classes.ps1
@@ -47,7 +47,7 @@ public sealed class AVSAttribute : Attribute {
 SecureFolder class provides a way to create a folder protected from CloudAdmins.
 #>
 if (-not ('AVSSecureFolder' -as [type])) {
-    Add-Type -ErrorAction Stop -TypeDefinition @"
+    Add-Type -ErrorAction Stop -TypeDefinition @'
 using System;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
@@ -120,5 +120,5 @@ return $folder
         return result.Count > 0 ? result[0].BaseObject : null;
     }
 }
-"@
+'@
 }

--- a/Microsoft.AVS.Management/Classes.ps1
+++ b/Microsoft.AVS.Management/Classes.ps1
@@ -46,60 +46,79 @@ public sealed class AVSAttribute : Attribute {
 <#
 SecureFolder class provides a way to create a folder protected from CloudAdmins.
 #>
-class AVSSecureFolder {
-    hidden static [string]$vendors = "AVS-vendor-folders"
-    <#
-        Applies propagating permissions to specified objects.
-    #>
-    hidden static ApplyPermissions($objects) {
-        $admin = Get-VIRole -Name "Admin" -ErrorAction Stop
-        $readOnly = Get-VIRole -Name "ReadOnly" -ErrorAction Stop
-        $scripting = Get-VIAccount -Id "scripting" -Domain "vsphere.local" -ErrorAction Stop
-        $group = Get-VIAccount -Group -Id "CloudAdmins" -Domain "vsphere.local" -ErrorAction Stop
-        $objects | New-VIPermission -Principal $scripting -Role $admin -Propagate $true
-        $objects | New-VIPermission -Principal $group -Role $readOnly -Propagate $true
-        if ($objects.Folder -ne [AVSSecureFolder]::Root()) {
-            $external = `
-                $objects | Get-VIPermission `
-                | Where-Object { -not $_.Principal.StartsWith("VSPHERE.LOCAL") } `
-                | ForEach-Object { Get-VIAccount -Group:$_.IsGroup -Domain $_.Principal.Split("\")[0] -Id $_.Principal.Split("\")[1]}
-            foreach ($x in $external) {
-                $objects | New-VIPermission -Principal $x -Role $readOnly -Propagate $true
-            }
-        }
+if (-not ('AVSSecureFolder' -as [type])) {
+    Add-Type -ErrorAction Stop -TypeDefinition @"
+using System;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+
+public sealed class AVSSecureFolder {
+    private static readonly string vendors = "AVS-vendor-folders";
+
+    private static Collection<PSObject> Invoke(string script, params object[] args) {
+        return ScriptBlock.Create(script).Invoke(args);
     }
 
-    <#
-        Returns vendors root folder or $null in case of any error.
-    #>
-    static [VMware.VimAutomation.ViCore.Types.V1.Inventory.Folder] Root() {
-        $location = Get-Folder -Location ((Get-Datacenter)[0]) -Name "vm"
-        $root = Get-Folder -Name ([AVSSecureFolder]::vendors) -NoRecursion -Location $location -ErrorAction SilentlyContinue
-        if ($null -eq $root) {
-            $root = New-Folder -Location $location -Name ([AVSSecureFolder]::vendors) -ErrorAction Stop
-            [AVSSecureFolder]::ApplyPermissions($root)
+    public static void ApplyPermissions(object objects) {
+        Invoke(@"
+param($objects)
+$admin = Get-VIRole -Name ""Admin"" -ErrorAction Stop
+$readOnly = Get-VIRole -Name ""ReadOnly"" -ErrorAction Stop
+$scripting = Get-VIAccount -Id ""scripting"" -Domain ""vsphere.local"" -ErrorAction Stop
+$group = Get-VIAccount -Group -Id ""CloudAdmins"" -Domain ""vsphere.local"" -ErrorAction Stop
+$objects | New-VIPermission -Principal $scripting -Role $admin -Propagate $true
+$objects | New-VIPermission -Principal $group -Role $readOnly -Propagate $true
+if ($objects.Folder -ne [AVSSecureFolder]::Root()) {
+    $external = $objects | Get-VIPermission |
+        Where-Object { -not $_.Principal.StartsWith(""VSPHERE.LOCAL"") } |
+        ForEach-Object {
+            $parts = $_.Principal -split '\\', 2
+            Get-VIAccount -Group:$_.IsGroup -Domain $parts[0] -Id $parts[1]
         }
-        return $root
+
+    foreach ($x in $external) {
+        $objects | New-VIPermission -Principal $x -Role $readOnly -Propagate $true
+    }
+}
+", objects);
     }
 
-    <#
-        Secure all objects in the specified folder.
-    #>
-    static Secure([VMware.VimAutomation.ViCore.Types.V1.Inventory.Folder]$folder) {
-        $objects = @(Get-VM -Location $folder) + @(Get-VApp -Location $folder)
-        [AVSSecureFolder]::ApplyPermissions($objects)
+    public static object Root() {
+        var result = Invoke(@"
+param($vendors)
+$location = Get-Folder -Location ((Get-Datacenter)[0]) -Name ""vm""
+$root = Get-Folder -Name $vendors -NoRecursion -Location $location -ErrorAction SilentlyContinue
+if ($null -eq $root) {
+    $root = New-Folder -Location $location -Name $vendors -ErrorAction Stop
+    [AVSSecureFolder]::ApplyPermissions($root)
+}
+return $root
+", vendors);
+
+        return result.Count > 0 ? result[0].BaseObject : null;
     }
 
-    <#
-        Creates a subfolder or returns existing one given the name.
-        Returns $null in case of any error.
-    #>
-    static [VMware.VimAutomation.ViCore.Types.V1.Inventory.Folder] GetOrCreate([string]$name) {
-        $root = [AVSSecureFolder]::Root()
-        $folder = Get-Folder -Location $root -Name $name -NoRecursion -ErrorAction SilentlyContinue
-        if ($null -eq $folder) {
-            $folder = New-Folder -Location $root -Name $name -ErrorAction Stop
-        }
-        return $folder
+    public static void Secure(object folder) {
+        Invoke(@"
+param($folder)
+$objects = @(Get-VM -Location $folder) + @(Get-VApp -Location $folder)
+[AVSSecureFolder]::ApplyPermissions($objects)
+", folder);
     }
+
+    public static object GetOrCreate(string name) {
+        var result = Invoke(@"
+param($name)
+$root = [AVSSecureFolder]::Root()
+$folder = Get-Folder -Location $root -Name $name -NoRecursion -ErrorAction SilentlyContinue
+if ($null -eq $folder) {
+    $folder = New-Folder -Location $root -Name $name -ErrorAction Stop
+}
+return $folder
+", name);
+
+        return result.Count > 0 ? result[0].BaseObject : null;
+    }
+}
+"@
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -148,9 +148,9 @@ Make sure that the assembly that contains this type is loaded.
 
 Root cause: in those versions `AVSAttribute` is defined as a PowerShell `class` in `Classes.ps1` (run via `ScriptsToProcess`). When CDR's pinned-import functions call `Import-Module` from inside their own function body, that class registers into CDR's SessionState type table and is not visible to consumer scripts that dot-source `[AVSAttribute]`-decorated functions from sub-files. Functions decorated inline in the consumer's `.psm1` are unaffected; only dot-sourced files break.
 
-**Fix going forward**: starting with `Microsoft.AVS.Management` 10.0.250, `AVSAttribute` is defined via `Add-Type` and lives in the AppDomain — the bug cannot occur. Take the dependency to 10.0.250+ when possible.
+**Fix going forward**: starting with `Microsoft.AVS.Management` 10.0.251, `AVSAttribute` is defined via `Add-Type` and lives in the AppDomain — the bug cannot occur. Take the dependency to 10.0.251+ when possible.
 
-**Transitional pattern** for consumers that cannot yet upgrade to 10.0.250+: replace `Import-ModulePinned` / `Import-PSResourceDependencies` with `Find-PSResourcesPinned` + a caller-driven top-level `Import-Module` loop. Because the imports run at top-level scope (not inside a CDR function), `ScriptsToProcess` registers the PS-class into the runspace where consumers can resolve it. `Find-PSResourcesPinned` already returns dependencies in topological order, so a plain sequential `foreach` is sufficient — no extra ordering logic is required.
+**Transitional pattern** for consumers that cannot yet upgrade to 10.0.251+: replace `Import-ModulePinned` / `Import-PSResourceDependencies` with `Find-PSResourcesPinned` + a caller-driven top-level `Import-Module` loop. Because the imports run at top-level scope (not inside a CDR function), `ScriptsToProcess` registers the PS-class into the runspace where consumers can resolve it. `Find-PSResourcesPinned` already returns dependencies in topological order, so a plain sequential `foreach` is sufficient — no extra ordering logic is required.
 
 ```powershell
 # Transitional pattern (works regardless of Management version)
@@ -160,7 +160,7 @@ foreach ($r in $resolved) {
 }
 ```
 
-Once the consumer's `Microsoft.AVS.Management` dependency is at 10.0.250 or later, `Import-ModulePinned` and `Import-PSResourceDependencies` can be used directly again — both code paths produce correct results, and the transitional pattern can be removed.
+Once the consumer's `Microsoft.AVS.Management` dependency is at 10.0.251 or later, `Import-ModulePinned` and `Import-PSResourceDependencies` can be used directly again — both code paths produce correct results, and the transitional pattern can be removed.
 
 ### 2.3 Versioning
 

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -1,14 +1,8 @@
 BeforeAll {
-    # Define the AVSAttribute class that Management module functions use
-    # This is a minimal definition matching what's in Microsoft.AVS.Management/Classes.ps1
-    if (-not ('AVSAttribute' -as [type])) {
-        class AVSAttribute : Attribute {
-            [bool]$UpdatesSDDC = $false
-            [TimeSpan]$Timeout
-            [bool]$AutomationOnly = $false
-            AVSAttribute([int]$timeoutMinutes) { $this.Timeout = New-TimeSpan -Minutes $timeoutMinutes }
-        }
-    }
+    # AVSAttribute and AVSSecureFolder are loaded from Classes.ps1 via
+    # ScriptsToProcess when Import-Module runs below. Do not pre-define them
+    # with the PowerShell 'class' keyword — that would prevent Add-Type from
+    # running (its if (-not ...) guard) and defeat cross-SessionState visibility.
 
     # Define stub functions for VMware cmdlets so Pester can mock them
     # These are only created when the real cmdlets are not available (e.g. no PowerCLI installed)
@@ -1250,5 +1244,53 @@ Describe "Get-EsxtopData" {
             $cmdletBindingAttr = $cmd.ScriptBlock.Attributes | Where-Object { $_ -is [System.Management.Automation.CmdletBindingAttribute] }
             $cmdletBindingAttr | Should -Not -BeNullOrEmpty
         }
+    }
+}
+
+Describe "Classes.ps1 - Cross-SessionState Type Visibility" {
+    <#
+    Validates that AVSAttribute and AVSSecureFolder (both defined via Add-Type in Classes.ps1)
+    are visible from a module SessionState that is different from the one in which Classes.ps1 was
+    loaded. This is the exact scenario that broke with the old PowerShell 'class' keyword:
+
+    When CDR's Import-ModulePinned calls Import-Module Microsoft.AVS.Management from inside a
+    module function, ScriptsToProcess (Classes.ps1) runs in CDR's module SessionState. Any module
+    that then dot-sources a .ps1 referencing [AVSAttribute] or [AVSSecureFolder] from its own
+    SessionState would fail with 'Unable to find type' if those types were defined via 'class'.
+    Add-Type registers types in the process AppDomain, making them visible everywhere.
+
+    The test uses a subprocess (fresh pwsh) so that no prior Add-Type call in the current
+    process's AppDomain can mask a regression.
+    #>
+
+    It "AVSAttribute and AVSSecureFolder resolve from a separate module scope" {
+        $classesPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.Management' 'Classes.ps1')).Path
+
+        # Escape single quotes in path for embedding in a single-quoted here-string
+        $escapedPath = $classesPath -replace "'", "''"
+
+        # Script runs in a fresh pwsh process: no AppDomain contamination from BeforeAll's Import-Module.
+        # Step 1 – load Classes.ps1 inside a module's SessionState (simulates CDR's Import-ModulePinned).
+        # Step 2 – resolve both types from a *different* module's function scope.
+        $script = @"
+`$loaderModule = New-Module -Name 'SimulatedCDR' -ScriptBlock ([scriptblock]::Create(". '$escapedPath'"))
+Import-Module `$loaderModule -Force
+
+`$consumerModule = New-Module -Name 'SimulatedManagement' -ScriptBlock {
+    function Test-TypeVisibility {
+        `$missing = @('AVSAttribute', 'AVSSecureFolder') | Where-Object { -not (`$_ -as [type]) }
+        if (`$missing) { throw "Types not visible in consumer module scope: `$(`$missing -join ', ')" }
+        'ok'
+    }
+}
+Import-Module `$consumerModule -Force
+& (Get-Module SimulatedManagement) { Test-TypeVisibility }
+"@
+        $output = pwsh -NoProfile -NonInteractive -Command $script 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because (
+            "Add-Type registers types in the AppDomain — they must be visible from any module scope. " +
+            "stderr: $($output | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] })"
+        )
+        $output | Should -Contain 'ok'
     }
 }

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -1265,16 +1265,20 @@ Describe "Classes.ps1 - Cross-SessionState Type Visibility" {
 
     It "AVSAttribute and AVSSecureFolder resolve from a separate module scope" {
         $classesPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.Management' 'Classes.ps1')).Path
+        $cdrPath     = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.CDR'        'Microsoft.AVS.CDR.psd1')).Path
 
-        # Escape single quotes in path for embedding in a single-quoted here-string
-        $escapedPath = $classesPath -replace "'", "''"
+        # Escape single quotes in paths for embedding in a here-string
+        $escapedClassesPath = $classesPath -replace "'", "''"
+        $escapedCdrPath     = $cdrPath     -replace "'", "''"
 
         # Script runs in a fresh pwsh process: no AppDomain contamination from BeforeAll's Import-Module.
-        # Step 1 – load Classes.ps1 inside a module's SessionState (simulates CDR's Import-ModulePinned).
-        # Step 2 – resolve both types from a *different* module's function scope.
+        # Step 1 – import the real CDR module.
+        # Step 2 – dot-source Classes.ps1 inside CDR's module SessionState (mirrors ScriptsToProcess behavior).
+        # Step 3 – verify both types are visible from a separate module's function scope.
         $script = @"
-`$loaderModule = New-Module -Name 'SimulatedCDR' -ScriptBlock ([scriptblock]::Create(". '$escapedPath'"))
-Import-Module `$loaderModule -Force
+Import-Module '$escapedCdrPath' -Force
+
+& (Get-Module Microsoft.AVS.CDR) { param(`$p) . `$p } -p '$escapedClassesPath'
 
 `$consumerModule = New-Module -Name 'SimulatedManagement' -ScriptBlock {
     function Test-TypeVisibility {

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -1266,122 +1266,37 @@ Describe "Classes.ps1 - Cross-SessionState Type Visibility" {
     It "AVSAttribute and AVSSecureFolder resolve from a separate module scope" {
         $cdrPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.CDR' 'Microsoft.AVS.CDR.psd1')).Path
         $managementManifestPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.Management' 'Microsoft.AVS.Management.psd1')).Path
-        $managementSourcePath = Split-Path -Path $managementManifestPath -Parent
+        $managementVersion = [string](Import-PowerShellDataFile $managementManifestPath).ModuleVersion
 
-        $managementManifest = Import-PowerShellDataFile $managementManifestPath
-        $managementVersion = [string]$managementManifest.ModuleVersion
-        $requiredModules = @(
-            $managementManifest.RequiredModules | ForEach-Object {
-                [PSCustomObject]@{
-                    Name = $_.ModuleName
-                    Version = [string]($(if ($_.RequiredVersion) { $_.RequiredVersion } else { $_.ModuleVersion }))
-                }
-            }
-        )
+        # CDR's Import-ModulePinned uses Get-PSResource, which only sees modules installed to the
+        # PSResourceGet user/all-users scopes. Skip with a precondition message when the current
+        # source version isn't installed (e.g. fresh laptop), so the test never silently no-ops.
+        $installed = Get-PSResource -Name 'Microsoft.AVS.Management' -Version $managementVersion -ErrorAction SilentlyContinue
+        if (-not $installed) {
+            Set-ItResult -Skipped -Because "Microsoft.AVS.Management $managementVersion is not installed as a PSResource on this host. Install it (or run on a host that has it, e.g. CI) to exercise the cross-SessionState path."
+            return
+        }
 
         # Escape single quotes for embedding in a script passed to pwsh -Command
         $escapedCdrPath = $cdrPath -replace "'", "''"
-        $escapedManagementSourcePath = $managementSourcePath -replace "'", "''"
         $escapedManagementVersion = $managementVersion -replace "'", "''"
-        $escapedRequiredModulesJson = (($requiredModules | ConvertTo-Json -Compress) -replace "'", "''")
 
-        # Script runs in a fresh pwsh process: no AppDomain contamination from BeforeAll's Import-Module.
-        # It imports Management using CDR's real Import-ModulePinned path, with local stub dependency
-        # modules in a temporary PSModulePath to keep the test self-contained.
+        # Subprocess keeps the AppDomain clean so a pre-loaded Add-Type in this process can't mask
+        # a regression. CDR's Import-ModulePinned does the real work; we just observe type visibility.
         $script = @"
 `$ErrorActionPreference = 'Stop'
+Import-Module '$escapedCdrPath' -Force
+Import-ModulePinned -Name 'Microsoft.AVS.Management' -RequiredVersion '$escapedManagementVersion' -Force
 
-function New-StubModule {
-    param(
-        [Parameter(Mandatory = `$true)][string]`$Name,
-        [Parameter(Mandatory = `$true)][string]`$Version,
-        [Parameter(Mandatory = `$true)][string]`$Root
-    )
-
-    `$moduleVersionPath = Join-Path (Join-Path `$Root `$Name) `$Version
-    New-Item -ItemType Directory -Path `$moduleVersionPath -Force | Out-Null
-
-    `$psm1Path = Join-Path `$moduleVersionPath ("`$Name.psm1")
-    `$psd1Path = Join-Path `$moduleVersionPath ("`$Name.psd1")
-
-    Set-Content -Path `$psm1Path -Value '' -Encoding utf8
-    New-ModuleManifest -Path `$psd1Path -RootModule ("`$Name.psm1") -ModuleVersion `$Version -Guid ([guid]::NewGuid()) -FunctionsToExport @() -CmdletsToExport @() -AliasesToExport @() -VariablesToExport @() | Out-Null
-}
-
-`$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("avs-cdr-pinned-import-test-" + [guid]::NewGuid().ToString('N'))
-`$moduleRoot = Join-Path `$tempRoot 'Modules'
-`$originalModulePath = `$env:PSModulePath
-
-try {
-    New-Item -ItemType Directory -Path `$moduleRoot -Force | Out-Null
-
-    `$managementVersionPath = Join-Path (Join-Path `$moduleRoot 'Microsoft.AVS.Management') '$escapedManagementVersion'
-    New-Item -ItemType Directory -Path `$managementVersionPath -Force | Out-Null
-    Copy-Item -Path (Join-Path '$escapedManagementSourcePath' '*') -Destination `$managementVersionPath -Recurse -Force
-
-    `$requiredModules = ConvertFrom-Json -InputObject '$escapedRequiredModulesJson'
-    foreach (`$dep in `$requiredModules) {
-        New-StubModule -Name `$dep.Name -Version `$dep.Version -Root `$moduleRoot
+`$consumer = New-Module -Name 'TypeVisibilityConsumer' -ScriptBlock {
+    function Test-TypeVisibility {
+        `$missing = @('AVSAttribute', 'AVSSecureFolder') | Where-Object { -not (`$_ -as [type]) }
+        if (`$missing) { throw "Types not visible in consumer module scope: `$(`$missing -join ', ')" }
+        'ok'
     }
-
-    `$env:PSModulePath = "`${moduleRoot}`$([System.IO.Path]::PathSeparator)`${originalModulePath}"
-
-    Import-Module '$escapedCdrPath' -Force
-
-    function global:Get-PSResource {
-        param(
-            [Parameter(Mandatory = `$false)][string]`$Name,
-            [Parameter(Mandatory = `$false)][string]`$Version
-        )
-
-        `$managementName = 'Microsoft.AVS.Management'
-        `$managementVersion = '$escapedManagementVersion'
-
-        if (`$Name -ieq `$managementName -and (`$Version -eq `$managementVersion -or [string]::IsNullOrWhiteSpace(`$Version))) {
-            `$deps = @(`$requiredModules | ForEach-Object {
-                [PSCustomObject]@{ Name = `$_.Name; VersionRange = `$_.Version }
-            })
-
-            return [PSCustomObject]@{
-                Name = `$managementName
-                Version = [version]`$managementVersion
-                Dependencies = `$deps
-                InstalledLocation = `$moduleRoot
-            }
-        }
-
-        foreach (`$dep in `$requiredModules) {
-            if (`$Name -ieq `$dep.Name -and (`$Version -eq `$dep.Version -or [string]::IsNullOrWhiteSpace(`$Version))) {
-                return [PSCustomObject]@{
-                    Name = `$dep.Name
-                    Version = [version]`$dep.Version
-                    Dependencies = @()
-                    InstalledLocation = `$moduleRoot
-                }
-            }
-        }
-
-        return @()
-    }
-
-    Import-ModulePinned -Name 'Microsoft.AVS.Management' -RequiredVersion '$escapedManagementVersion' -Force
-
-    `$consumerModule = New-Module -Name 'TypeVisibilityConsumer' -ScriptBlock {
-        function Test-TypeVisibility {
-            `$missing = @('AVSAttribute', 'AVSSecureFolder') | Where-Object { -not (`$_ -as [type]) }
-            if (`$missing) { throw "Types not visible in consumer module scope: `$(`$missing -join ', ')" }
-            'ok'
-        }
-    }
-
-    Import-Module `$consumerModule -Force
-    & (Get-Module TypeVisibilityConsumer) { Test-TypeVisibility }
 }
-finally {
-    Remove-Item -Path Function:\Get-PSResource -ErrorAction SilentlyContinue
-    `$env:PSModulePath = `$originalModulePath
-    Remove-Item -Path `$tempRoot -Recurse -Force -ErrorAction SilentlyContinue
-}
+Import-Module `$consumer -Force
+& (Get-Module TypeVisibilityConsumer) { Test-TypeVisibility }
 "@
         $output = pwsh -NoProfile -NonInteractive -Command $script 2>&1
         $LASTEXITCODE | Should -Be 0 -Because (

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -1263,7 +1263,7 @@ Describe "Classes.ps1 - Cross-SessionState Type Visibility" {
     process's AppDomain can mask a regression.
     #>
 
-    It "AVSAttribute and AVSSecureFolder resolve from a separate module scope" {
+    It "Vendor module dot-sourcing a .ps1 that references [AVSAttribute] and [AVSSecureFolder] imports successfully" {
         $cdrPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.CDR' 'Microsoft.AVS.CDR.psd1')).Path
         $managementManifestPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.Management' 'Microsoft.AVS.Management.psd1')).Path
         $managementVersion = [string](Import-PowerShellDataFile $managementManifestPath).ModuleVersion
@@ -1277,30 +1277,65 @@ Describe "Classes.ps1 - Cross-SessionState Type Visibility" {
             return
         }
 
-        # Escape single quotes for embedding in a script passed to pwsh -Command
         $escapedCdrPath = $cdrPath -replace "'", "''"
         $escapedManagementVersion = $managementVersion -replace "'", "''"
 
-        # Subprocess keeps the AppDomain clean so a pre-loaded Add-Type in this process can't mask
-        # a regression. CDR's Import-ModulePinned does the real work; we just observe type visibility.
+        # Reproduce the exact production shape that triggered the original bug:
+        # CDR's Import-ModulePinned imports Management (Classes.ps1 runs in CDR's SessionState),
+        # then a *vendor* module gets imported whose .psm1 dot-sources a .ps1 containing function
+        # definitions decorated with [AVSAttribute(...)] and a body referencing [AVSSecureFolder].
+        # With the old PowerShell `class` keyword, the parser fails to bind [AVSAttribute] when
+        # dot-sourcing into the vendor's SessionState. With Add-Type, the AppDomain-registered
+        # types resolve fine. Subprocess keeps the AppDomain clean to avoid masking a regression.
         $script = @"
 `$ErrorActionPreference = 'Stop'
-Import-Module '$escapedCdrPath' -Force
-Import-ModulePinned -Name 'Microsoft.AVS.Management' -RequiredVersion '$escapedManagementVersion' -Force
 
-`$consumer = New-Module -Name 'TypeVisibilityConsumer' -ScriptBlock {
-    function Test-TypeVisibility {
-        `$missing = @('AVSAttribute', 'AVSSecureFolder') | Where-Object { -not (`$_ -as [type]) }
-        if (`$missing) { throw "Types not visible in consumer module scope: `$(`$missing -join ', ')" }
-        'ok'
-    }
+`$vendorRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("avs-vendor-consumer-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path `$vendorRoot -Force | Out-Null
+
+try {
+    `$vendorImpl = Join-Path `$vendorRoot 'Vendor.Impl.ps1'
+    `$vendorPsm1 = Join-Path `$vendorRoot 'Vendor.psm1'
+    `$vendorPsd1 = Join-Path `$vendorRoot 'Vendor.psd1'
+
+    Set-Content -Path `$vendorImpl -Encoding utf8 -Value @'
+function Invoke-VendorAction {
+    [CmdletBinding()]
+    [AVSAttribute(5, UpdatesSDDC = `$false)]
+    param()
+
+    # Body references AVSSecureFolder to exercise type binding from a dot-sourced .ps1
+    [void][AVSSecureFolder]
+    'invoked'
 }
-Import-Module `$consumer -Force
-& (Get-Module TypeVisibilityConsumer) { Test-TypeVisibility }
+'@
+
+    Set-Content -Path `$vendorPsm1 -Encoding utf8 -Value '. (Join-Path `$PSScriptRoot ''Vendor.Impl.ps1'')'
+
+    New-ModuleManifest -Path `$vendorPsd1 -RootModule 'Vendor.psm1' -ModuleVersion '1.0.0' ``
+        -Guid ([guid]::NewGuid()) -FunctionsToExport @('Invoke-VendorAction') ``
+        -CmdletsToExport @() -AliasesToExport @() -VariablesToExport @()
+
+    Import-Module '$escapedCdrPath' -Force
+    Import-ModulePinned -Name 'Microsoft.AVS.Management' -RequiredVersion '$escapedManagementVersion' -Force
+
+    # Dot-source-with-AVSAttribute happens here. Fails at parse time under the old `class` design.
+    Import-Module `$vendorPsd1 -Force
+
+    `$cmd = Get-Command Invoke-VendorAction -ErrorAction Stop
+    `$attr = `$cmd.ScriptBlock.Attributes | Where-Object { `$_.GetType().Name -eq 'AVSAttribute' } | Select-Object -First 1
+    if (-not `$attr) { throw 'AVSAttribute was not bound on Invoke-VendorAction' }
+    if (`$attr.Timeout.TotalMinutes -ne 5) { throw "Expected timeout 5, got `$(`$attr.Timeout.TotalMinutes)" }
+
+    'ok'
+}
+finally {
+    Remove-Item -Path `$vendorRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
 "@
         $output = pwsh -NoProfile -NonInteractive -Command $script 2>&1
         $LASTEXITCODE | Should -Be 0 -Because (
-            "Add-Type registers types in the AppDomain — they must be visible from any module scope. " +
+            "Add-Type registers types in the AppDomain so dot-sourced .ps1 files in vendor module SessionStates can parse [AVSAttribute] and [AVSSecureFolder]. " +
             "stderr: $($output | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] })"
         )
         $output | Should -Contain 'ok'

--- a/tests/Microsoft.AVS.Management.Tests.ps1
+++ b/tests/Microsoft.AVS.Management.Tests.ps1
@@ -1264,31 +1264,124 @@ Describe "Classes.ps1 - Cross-SessionState Type Visibility" {
     #>
 
     It "AVSAttribute and AVSSecureFolder resolve from a separate module scope" {
-        $classesPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.Management' 'Classes.ps1')).Path
-        $cdrPath     = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.CDR'        'Microsoft.AVS.CDR.psd1')).Path
+        $cdrPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.CDR' 'Microsoft.AVS.CDR.psd1')).Path
+        $managementManifestPath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'Microsoft.AVS.Management' 'Microsoft.AVS.Management.psd1')).Path
+        $managementSourcePath = Split-Path -Path $managementManifestPath -Parent
 
-        # Escape single quotes in paths for embedding in a here-string
-        $escapedClassesPath = $classesPath -replace "'", "''"
-        $escapedCdrPath     = $cdrPath     -replace "'", "''"
+        $managementManifest = Import-PowerShellDataFile $managementManifestPath
+        $managementVersion = [string]$managementManifest.ModuleVersion
+        $requiredModules = @(
+            $managementManifest.RequiredModules | ForEach-Object {
+                [PSCustomObject]@{
+                    Name = $_.ModuleName
+                    Version = [string]($(if ($_.RequiredVersion) { $_.RequiredVersion } else { $_.ModuleVersion }))
+                }
+            }
+        )
+
+        # Escape single quotes for embedding in a script passed to pwsh -Command
+        $escapedCdrPath = $cdrPath -replace "'", "''"
+        $escapedManagementSourcePath = $managementSourcePath -replace "'", "''"
+        $escapedManagementVersion = $managementVersion -replace "'", "''"
+        $escapedRequiredModulesJson = (($requiredModules | ConvertTo-Json -Compress) -replace "'", "''")
 
         # Script runs in a fresh pwsh process: no AppDomain contamination from BeforeAll's Import-Module.
-        # Step 1 – import the real CDR module.
-        # Step 2 – dot-source Classes.ps1 inside CDR's module SessionState (mirrors ScriptsToProcess behavior).
-        # Step 3 – verify both types are visible from a separate module's function scope.
+        # It imports Management using CDR's real Import-ModulePinned path, with local stub dependency
+        # modules in a temporary PSModulePath to keep the test self-contained.
         $script = @"
-Import-Module '$escapedCdrPath' -Force
+`$ErrorActionPreference = 'Stop'
 
-& (Get-Module Microsoft.AVS.CDR) { param(`$p) . `$p } -p '$escapedClassesPath'
+function New-StubModule {
+    param(
+        [Parameter(Mandatory = `$true)][string]`$Name,
+        [Parameter(Mandatory = `$true)][string]`$Version,
+        [Parameter(Mandatory = `$true)][string]`$Root
+    )
 
-`$consumerModule = New-Module -Name 'SimulatedManagement' -ScriptBlock {
-    function Test-TypeVisibility {
-        `$missing = @('AVSAttribute', 'AVSSecureFolder') | Where-Object { -not (`$_ -as [type]) }
-        if (`$missing) { throw "Types not visible in consumer module scope: `$(`$missing -join ', ')" }
-        'ok'
-    }
+    `$moduleVersionPath = Join-Path (Join-Path `$Root `$Name) `$Version
+    New-Item -ItemType Directory -Path `$moduleVersionPath -Force | Out-Null
+
+    `$psm1Path = Join-Path `$moduleVersionPath ("`$Name.psm1")
+    `$psd1Path = Join-Path `$moduleVersionPath ("`$Name.psd1")
+
+    Set-Content -Path `$psm1Path -Value '' -Encoding utf8
+    New-ModuleManifest -Path `$psd1Path -RootModule ("`$Name.psm1") -ModuleVersion `$Version -Guid ([guid]::NewGuid()) -FunctionsToExport @() -CmdletsToExport @() -AliasesToExport @() -VariablesToExport @() | Out-Null
 }
-Import-Module `$consumerModule -Force
-& (Get-Module SimulatedManagement) { Test-TypeVisibility }
+
+`$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("avs-cdr-pinned-import-test-" + [guid]::NewGuid().ToString('N'))
+`$moduleRoot = Join-Path `$tempRoot 'Modules'
+`$originalModulePath = `$env:PSModulePath
+
+try {
+    New-Item -ItemType Directory -Path `$moduleRoot -Force | Out-Null
+
+    `$managementVersionPath = Join-Path (Join-Path `$moduleRoot 'Microsoft.AVS.Management') '$escapedManagementVersion'
+    New-Item -ItemType Directory -Path `$managementVersionPath -Force | Out-Null
+    Copy-Item -Path (Join-Path '$escapedManagementSourcePath' '*') -Destination `$managementVersionPath -Recurse -Force
+
+    `$requiredModules = ConvertFrom-Json -InputObject '$escapedRequiredModulesJson'
+    foreach (`$dep in `$requiredModules) {
+        New-StubModule -Name `$dep.Name -Version `$dep.Version -Root `$moduleRoot
+    }
+
+    `$env:PSModulePath = "`${moduleRoot}`$([System.IO.Path]::PathSeparator)`${originalModulePath}"
+
+    Import-Module '$escapedCdrPath' -Force
+
+    function global:Get-PSResource {
+        param(
+            [Parameter(Mandatory = `$false)][string]`$Name,
+            [Parameter(Mandatory = `$false)][string]`$Version
+        )
+
+        `$managementName = 'Microsoft.AVS.Management'
+        `$managementVersion = '$escapedManagementVersion'
+
+        if (`$Name -ieq `$managementName -and (`$Version -eq `$managementVersion -or [string]::IsNullOrWhiteSpace(`$Version))) {
+            `$deps = @(`$requiredModules | ForEach-Object {
+                [PSCustomObject]@{ Name = `$_.Name; VersionRange = `$_.Version }
+            })
+
+            return [PSCustomObject]@{
+                Name = `$managementName
+                Version = [version]`$managementVersion
+                Dependencies = `$deps
+                InstalledLocation = `$moduleRoot
+            }
+        }
+
+        foreach (`$dep in `$requiredModules) {
+            if (`$Name -ieq `$dep.Name -and (`$Version -eq `$dep.Version -or [string]::IsNullOrWhiteSpace(`$Version))) {
+                return [PSCustomObject]@{
+                    Name = `$dep.Name
+                    Version = [version]`$dep.Version
+                    Dependencies = @()
+                    InstalledLocation = `$moduleRoot
+                }
+            }
+        }
+
+        return @()
+    }
+
+    Import-ModulePinned -Name 'Microsoft.AVS.Management' -RequiredVersion '$escapedManagementVersion' -Force
+
+    `$consumerModule = New-Module -Name 'TypeVisibilityConsumer' -ScriptBlock {
+        function Test-TypeVisibility {
+            `$missing = @('AVSAttribute', 'AVSSecureFolder') | Where-Object { -not (`$_ -as [type]) }
+            if (`$missing) { throw "Types not visible in consumer module scope: `$(`$missing -join ', ')" }
+            'ok'
+        }
+    }
+
+    Import-Module `$consumerModule -Force
+    & (Get-Module TypeVisibilityConsumer) { Test-TypeVisibility }
+}
+finally {
+    Remove-Item -Path Function:\Get-PSResource -ErrorAction SilentlyContinue
+    `$env:PSModulePath = `$originalModulePath
+    Remove-Item -Path `$tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
 "@
         $output = pwsh -NoProfile -NonInteractive -Command $script 2>&1
         $LASTEXITCODE | Should -Be 0 -Because (


### PR DESCRIPTION
## Summary
- convert AVSSecureFolder from a PowerShell class to an Add-Type compiled C# type
- keep Root, Secure, and GetOrCreate behavior aligned with previous implementation
- align type visibility behavior with AVSAttribute to avoid SessionState scoping issues

## Validation
Unit-tests