### PR TITLE
Pin Microsoft.AVS.Management dependency to 10.0.252

### DIFF
--- a/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psd1
+++ b/Microsoft.AVS.NFS/Microsoft.AVS.NFS.psd1
@@ -8,7 +8,7 @@
     RootModule = 'Microsoft.AVS.NFS.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.0'
+    ModuleVersion = '1.0.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ ModuleName = "Microsoft.AVS.Management"; RequiredVersion = "8.0.201" }
+        @{ ModuleName = "Microsoft.AVS.Management"; RequiredVersion = "10.0.252" }
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
+++ b/Microsoft.AVS.VMFS/Microsoft.AVS.VMFS.psd1
@@ -8,7 +8,7 @@
     RootModule = 'Microsoft.AVS.VMFS.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.1.0'
+    ModuleVersion = '1.1.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -48,7 +48,7 @@
 
     # Modules that must be imported into the global environment prior to importing this module
     RequiredModules = @(
-        @{ ModuleName = "Microsoft.AVS.Management"; RequiredVersion = "8.0.201" }
+        @{ ModuleName = "Microsoft.AVS.Management"; RequiredVersion = "10.0.252" }
     )
 
     # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
## Summary
Updates the `Microsoft.AVS.Management` dependency from `8.0.201` to `10.0.252` in the NFS and VMFS package manifests.

## Changes
- `Microsoft.AVS.NFS.psd1`: `RequiredVersion` 8.0.201 -> 10.0.252; 
- `Microsoft.AVS.VMFS.psd1`: `RequiredVersion` 8.0.201 -> 10.0.252; 

Patch versions bumped because package contents changed (a published version cannot be republished).

## Notes
- The CDR test fixture in `tests/Microsoft.AVS.CDR.Tests.ps1` intentionally pins a version *different* from the pipeline dependency so an install actually occurs during tests — left unchanged.
- Both manifests validated with `Test-ModuleManifest`.