### PR TITLE
CDR: fix nondeterministic pinned-import failure (stable topological order)

### DIFF
--- a/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psd1
+++ b/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psd1
@@ -9,7 +9,7 @@
 @{
     RootModule = 'Microsoft.AVS.CDR.psm1'
 
-    ModuleVersion = '2.0.0'
+    ModuleVersion = '2.1.0'
 
     # CompatiblePSEditions = @()
 

--- a/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psm1
+++ b/Microsoft.AVS.CDR/Microsoft.AVS.CDR.psm1
@@ -503,11 +503,17 @@ function Resolve-DiamondDependencies {
 <#
 .SYNOPSIS
     Returns module keys in topological order (dependencies first). Warns on cycles.
+    Traversal is anchored on -RootKeys (in given order) then a sorted pass over the
+    rest, so the order is deterministic and follows each node's reported dependency
+    order (matching native Import-Module's RequiredModules array-order walk).
 #>
 function Get-TopologicalOrder {
     param(
         [Parameter(Mandatory = $true)]
-        [hashtable]$Graph
+        [hashtable]$Graph,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$RootKeys
     )
     
     $visited = @{}
@@ -539,8 +545,17 @@ function Get-TopologicalOrder {
         $visited[$NodeKey] = $true
         [void]$order.Add($NodeKey)
     }
-    # Visit all nodes
-    foreach ($nodeKey in $Graph.Keys) {
+
+    # Anchor on the declared roots (in order), then a deterministic sorted pass over the rest.
+    if ($RootKeys) {
+        foreach ($rootKey in $RootKeys) {
+            if ($Graph.ContainsKey($rootKey)) {
+                Visit -NodeKey $rootKey
+            }
+        }
+    }
+
+    foreach ($nodeKey in ($Graph.Keys | Sort-Object)) {
         Visit -NodeKey $nodeKey
     }
     
@@ -698,7 +713,7 @@ function Install-PSResourcePinned {
     Resolve-DiamondDependencies -Graph $dependencyGraph
     
     Write-Verbose "Computing topological order"
-    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph)
+    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph -RootKeys @("${Name}@${RequiredVersion}"))
     
     Write-Verbose "Install order ($($topologicalOrder.Count) modules):"
     for ($i = 0; $i -lt $topologicalOrder.Count; $i++) {
@@ -828,7 +843,7 @@ function Save-PSResourcePinned {
     Resolve-DiamondDependencies -Graph $dependencyGraph
     
     Write-Verbose "Computing topological order"
-    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph)
+    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph -RootKeys @("${Name}@${RequiredVersion}"))
     
     Write-Verbose "Save order ($($topologicalOrder.Count) modules):"
     for ($i = 0; $i -lt $topologicalOrder.Count; $i++) {
@@ -1034,6 +1049,7 @@ function Find-PSResourceDependencies {
     Write-Verbose "Found $($moduleDependencies.Count) module dependency(ies) in manifest"
     
     $dependencyGraph = @{}
+    $rootKeys = [System.Collections.ArrayList]@()
     
     foreach ($depEntry in $moduleDependencies) {
         $moduleName = $depEntry.Name
@@ -1043,13 +1059,15 @@ function Find-PSResourceDependencies {
         $redirectResult = Find-DependencyRedirect -DependencyName $moduleName -DependencyVersion $moduleVersion `
             -RedirectMap $mergedRedirectMap -Indent ""
         
+        [void]$rootKeys.Add("$($redirectResult.ResolvedName)@$($redirectResult.ResolvedVersion)")
+        
         Build-RemoteDependencyGraph -ModuleName $redirectResult.ResolvedName -ModuleVersion $redirectResult.ResolvedVersion `
             -Graph $dependencyGraph -RedirectMap $mergedRedirectMap -Repository $Repository -Credential $Credential -Prerelease:$Prerelease
     }
     
     Resolve-DiamondDependencies -Graph $dependencyGraph
     
-    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph)
+    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph -RootKeys $rootKeys.ToArray())
     
     $resolvedDependencies = [System.Collections.ArrayList]@()
     
@@ -1222,6 +1240,7 @@ function Import-PSResourceDependencies {
     Write-Verbose "Found $($moduleDependencies.Count) module dependency(ies) in manifest"
     
     $dependencyGraph = @{}
+    $rootKeys = [System.Collections.ArrayList]@()
     
     foreach ($depEntry in $moduleDependencies) {
         $moduleName = $depEntry.Name
@@ -1231,6 +1250,8 @@ function Import-PSResourceDependencies {
         $redirectResult = Find-DependencyRedirect -DependencyName $moduleName -DependencyVersion $moduleVersion `
             -RedirectMap $mergedRedirectMap -Indent ""
         
+        [void]$rootKeys.Add("$($redirectResult.ResolvedName)@$($redirectResult.ResolvedVersion)")
+        
         Build-InstalledDependencyGraph -ModuleName $redirectResult.ResolvedName -ModuleVersion $redirectResult.ResolvedVersion `
             -Graph $dependencyGraph -RedirectMap $mergedRedirectMap
     }
@@ -1239,7 +1260,7 @@ function Import-PSResourceDependencies {
     
     # Compute topological order
     Write-Verbose "Computing topological order"
-    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph)
+    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph -RootKeys $rootKeys.ToArray())
     
     Write-Verbose "Import order ($($topologicalOrder.Count) modules):"
     for ($i = 0; $i -lt $topologicalOrder.Count; $i++) {
@@ -1455,7 +1476,7 @@ function Get-PSResourcesPinned {
     Resolve-DiamondDependencies -Graph $dependencyGraph
     
     Write-Verbose "Computing topological order"
-    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph)
+    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph -RootKeys @("${Name}@${RequiredVersion}"))
     
     $resolvedModules = [System.Collections.ArrayList]@()
     
@@ -1531,7 +1552,7 @@ function Find-PSResourcesPinned {
     Resolve-DiamondDependencies -Graph $dependencyGraph
     
     Write-Verbose "Computing topological order"
-    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph)
+    $topologicalOrder = @(Get-TopologicalOrder -Graph $dependencyGraph -RootKeys @("${Name}@${RequiredVersion}"))
     
     $resolvedModules = [System.Collections.ArrayList]@()
     

--- a/tests/Microsoft.AVS.CDR.Tests.ps1
+++ b/tests/Microsoft.AVS.CDR.Tests.ps1
@@ -1255,6 +1255,77 @@ Describe "Topological Dependency Loading" {
         }
     }
 
+    Context "Pinned import ordering scenario" {
+        # Covers the ~50% pinned-import failure of Microsoft.AVS.Management.Internal 1.1.490.
+        # AzTable depends on Az.Storage/Az.Resources only via a versionless '#Requires' in its
+        # source, so the graph records AzTable as a leaf (no edge). The root lists the Az modules
+        # before AzTable; anchoring on the root must keep that reported order so the pinned Az
+        # versions load before AzTable's #Requires can autoload higher ones. This is the same
+        # scenario the integration repro exercised end to end.
+
+        It "Should order a graph-leaf (source-level #Requires) module after its reported dependencies" {
+            InModuleScope Microsoft.AVS.CDR {
+                # AzTable has no edge to the Az modules, yet must still come after them.
+                $graph = @{
+                    "Root@1.0.0"         = [DependencyGraphNode]::new("Root", "1.0.0", @("Az.Storage@8.0.0", "Az.Resources@7.7.0", "AzTable@2.1.0"), $false, $null, $null)
+                    "Az.Storage@8.0.0"   = [DependencyGraphNode]::new("Az.Storage", "8.0.0", @("Az.Accounts@4.0.1"), $false, $null, $null)
+                    "Az.Resources@7.7.0" = [DependencyGraphNode]::new("Az.Resources", "7.7.0", @("Az.Accounts@4.0.1"), $false, $null, $null)
+                    "AzTable@2.1.0"      = [DependencyGraphNode]::new("AzTable", "2.1.0", @(), $false, $null, $null)
+                    "Az.Accounts@4.0.1"  = [DependencyGraphNode]::new("Az.Accounts", "4.0.1", @(), $false, $null, $null)
+                }
+
+                $result = @(Get-TopologicalOrder -Graph $graph -RootKeys @("Root@1.0.0"))
+
+                $result.IndexOf("Az.Storage@8.0.0") | Should -BeLessThan $result.IndexOf("AzTable@2.1.0")
+                $result.IndexOf("Az.Resources@7.7.0") | Should -BeLessThan $result.IndexOf("AzTable@2.1.0")
+            }
+        }
+
+        It "Should preserve the root's reported dependency order (deterministic)" {
+            InModuleScope Microsoft.AVS.CDR {
+                $graph = @{
+                    "Root@1.0.0"         = [DependencyGraphNode]::new("Root", "1.0.0", @("Az.Storage@8.0.0", "Az.Resources@7.7.0", "AzTable@2.1.0"), $false, $null, $null)
+                    "Az.Storage@8.0.0"   = [DependencyGraphNode]::new("Az.Storage", "8.0.0", @("Az.Accounts@4.0.1"), $false, $null, $null)
+                    "Az.Resources@7.7.0" = [DependencyGraphNode]::new("Az.Resources", "7.7.0", @("Az.Accounts@4.0.1"), $false, $null, $null)
+                    "AzTable@2.1.0"      = [DependencyGraphNode]::new("AzTable", "2.1.0", @(), $false, $null, $null)
+                    "Az.Accounts@4.0.1"  = [DependencyGraphNode]::new("Az.Accounts", "4.0.1", @(), $false, $null, $null)
+                }
+
+                $result = @(Get-TopologicalOrder -Graph $graph -RootKeys @("Root@1.0.0"))
+
+                ($result -join ",") | Should -Be "Az.Accounts@4.0.1,Az.Storage@8.0.0,Az.Resources@7.7.0,AzTable@2.1.0,Root@1.0.0"
+            }
+        }
+
+        It "Should be deterministic regardless of graph key insertion order" {
+            InModuleScope Microsoft.AVS.CDR {
+                # Build the same logical graph twice, adding keys in opposite orders, to prove the
+                # result no longer depends on hashtable enumeration (the original ~50% failure).
+                $build = {
+                    param([string[]]$Order)
+                    $nodes = @{
+                        "Root@1.0.0"         = [DependencyGraphNode]::new("Root", "1.0.0", @("Az.Storage@8.0.0", "Az.Resources@7.7.0", "AzTable@2.1.0"), $false, $null, $null)
+                        "Az.Storage@8.0.0"   = [DependencyGraphNode]::new("Az.Storage", "8.0.0", @("Az.Accounts@4.0.1"), $false, $null, $null)
+                        "Az.Resources@7.7.0" = [DependencyGraphNode]::new("Az.Resources", "7.7.0", @("Az.Accounts@4.0.1"), $false, $null, $null)
+                        "AzTable@2.1.0"      = [DependencyGraphNode]::new("AzTable", "2.1.0", @(), $false, $null, $null)
+                        "Az.Accounts@4.0.1"  = [DependencyGraphNode]::new("Az.Accounts", "4.0.1", @(), $false, $null, $null)
+                    }
+                    $graph = @{}
+                    foreach ($k in $Order) { $graph[$k] = $nodes[$k] }
+                    $graph
+                }
+
+                $forward = @("Root@1.0.0", "Az.Storage@8.0.0", "Az.Resources@7.7.0", "AzTable@2.1.0", "Az.Accounts@4.0.1")
+                $reversed = @("Az.Accounts@4.0.1", "AzTable@2.1.0", "Az.Resources@7.7.0", "Az.Storage@8.0.0", "Root@1.0.0")
+
+                $orderA = @(Get-TopologicalOrder -Graph (& $build $forward) -RootKeys @("Root@1.0.0"))
+                $orderB = @(Get-TopologicalOrder -Graph (& $build $reversed) -RootKeys @("Root@1.0.0"))
+
+                ($orderA -join ",") | Should -Be ($orderB -join ",")
+            }
+        }
+    }
+
     Context "Compare-SemVer Function" {
         It "Should return 0 for equal versions" {
             InModuleScope Microsoft.AVS.CDR {


### PR DESCRIPTION
## Problem

`Import-ModulePinned -Name Microsoft.AVS.Management.Internal -RequiredVersion 1.1.490` fails intermittently — **~50% of attempts** (reproduced: 12/24 fresh processes) — with:

```
Failed to import Az.Storage 8.0.0: Could not load 'Azure.Storage.Blobs, Version=12.18.0.0' ... Assembly with same name is already loaded
Failed to import Az.Resources 7.7.0: Could not load 'Az.Authorization.private, Version=7.7.0.0' ... Assembly with same name is already loaded
```

## Root cause

`Get-TopologicalOrder` drove its DFS from PowerShell hashtable enumeration (`foreach ($Graph.Keys)`), which is **nondeterministic**. `AzTable 2.1.0` depends on `Az.Storage`/`Az.Resources` only via a **versionless `#Requires -Modules`** in its module source (`AzureRmStorageTableCoreHelper.psm1`) — an edge CDR's graph (built from `Get-PSResource`/`Find-PSResource` metadata + manifest `RequiredModules`) cannot see. So AzTable appears as a dependency-free leaf.

When the nondeterministic sort placed AzTable **before** the pinned `Az.Storage 8.0.0`/`Az.Resources 7.7.0`, AzTable's `#Requires` fired and PowerShell autoloaded the **highest installed** Az versions (8.1.0/7.8.0). Their bundled private assemblies won the default `AssemblyLoadContext` slot; CDR's later pinned bind of the same simple name from a different folder then threw *"assembly with same name is already loaded"*. Because module assemblies load into the single default ALC and cannot be unloaded, the first loader wins and there is no rollback.

## Fix

Make `Get-TopologicalOrder` **root-anchored and deterministic**:

- New optional `-RootKeys` parameter — the DFS visits the supplied roots first, in order, and each node's dependencies in reported order (post-order). This mirrors native `Import-Module`'s `RequiredModules` array-order walk, so the pinned Az versions are always imported before AzTable and its versionless `#Requires` **reuses** them (no higher-version autoload, no ALC clash).
- Any nodes unreachable from the roots are visited in a deterministic **sorted** fallback, removing the hashtable-enumeration nondeterminism.
- All six callers updated to pass `-RootKeys`.

Native `Import-Module` (no CDR) already handles this scenario deterministically (20/20) because it honors the manifest's `RequiredModules` array order; this change restores that ordering discipline in CDR while keeping its exact-version pinning.

## Testing

- New `Get-TopologicalOrder` **unit tests** ("Pinned import ordering scenario") reproduce the failure at the graph level — no real modules, no child processes:
  - a graph-leaf module (unreported `#Requires` dependency) is still ordered **after** its reported dependencies;
  - the root's reported dependency order is preserved (exact deterministic order);
  - the result is identical regardless of hashtable key insertion order (the original nondeterminism).
- Manually verified end-to-end during development: **before** 12/24 fresh-process pinned imports fail; **after** 24/24 pass with deterministic order.
- Existing `Topological Dependency Loading` tests unchanged and passing.
- Full non-integration suite: **189 passed, 0 failed, 22 skipped**.
- PSScriptAnalyzer (PSGallery): no new findings.
- Manifest bumped `2.0.0` → `2.1.0`.
