### PR TITLE
Add Microsoft.AVS.Migrate module with Deploy-MigrateApplianceVM cmdlet

### DIFF
--- a/Microsoft.AVS.Migrate/Microsoft.AVS.Migrate.psd1
+++ b/Microsoft.AVS.Migrate/Microsoft.AVS.Migrate.psd1
@@ -1,0 +1,130 @@
+#
+# Module manifest for module 'Microsoft.AVS.Migrate'
+#
+
+@{
+
+    # Script module or binary module file associated with this manifest.
+    RootModule = 'Microsoft.AVS.Migrate.psm1'
+
+    # Version number of this module.
+    ModuleVersion = '1.0.0'
+
+    # Supported PSEditions
+    # CompatiblePSEditions = @()
+
+    # ID used to uniquely identify this module
+    GUID = '3d9a2f6e-8c1b-4e7a-9f2d-6b1c4a8e5d3f'
+
+    # Author of this module
+    Author = 'Microsoft'
+
+    # Company or vendor of this module
+    CompanyName = 'Microsoft Corporation'
+
+    # Copyright statement for this module
+    Copyright = '(c) Microsoft. All rights reserved.'
+
+    # Description of the functionality provided by this module
+    Description = 'Azure VMware Solutions Azure Migrate appliance deployment cmdlets'
+
+    # Minimum version of the PowerShell engine required by this module
+    PowerShellVersion = '7.4'
+
+    # Name of the PowerShell host required by this module
+    # PowerShellHostName = ''
+
+    # Minimum version of the PowerShell host required by this module
+    # PowerShellHostVersion = ''
+
+    # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # DotNetFrameworkVersion = ''
+
+    # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+    # ClrVersion = ''
+
+    # Processor architecture (None, X86, Amd64) required by this module
+    # ProcessorArchitecture = ''
+
+    # Modules that must be imported into the global environment prior to importing this module
+    RequiredModules = @(
+        @{ ModuleName = "Microsoft.AVS.Management"; RequiredVersion = "8.0.201" }
+    )
+
+    # Assemblies that must be loaded prior to importing this module
+    # RequiredAssemblies = @()
+
+    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+    # ScriptsToProcess = @()
+
+    # Type files (.ps1xml) to be loaded when importing this module
+    # TypesToProcess = @()
+
+    # Format files (.ps1xml) to be loaded when importing this module
+    # FormatsToProcess = @()
+
+    # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+    # NestedModules = @()
+
+    # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+    FunctionsToExport = @(
+        "Deploy-MigrateApplianceVM"
+    )
+
+    # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+    CmdletsToExport = @()
+
+    # Variables to export from this module
+    VariablesToExport = '*'
+
+    # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+    AliasesToExport = @()
+
+    # DSC resources to export from this module
+    # DscResourcesToExport = @()
+
+    # List of all modules packaged with this module
+    # ModuleList = @()
+
+    # List of all files packaged with this module
+    # FileList = @()
+
+    # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+    PrivateData = @{
+
+    #Support for PowerShellGet galleries.
+        PSData = @{
+        # Tags applied to this module. These help with module discovery in online galleries.
+            Tags = @("VMware", "PowerCLI", "Azure", "AVS", "Migrate")
+
+            # A URL to the license for this module.
+            LicenseUri = 'https://raw.githubusercontent.com/Azure/Microsoft.AVS.Management/refs/heads/main/LICENSE'
+
+            # A URL to the main website for this project.
+            ProjectUri = 'https://github.com/Azure/Microsoft.AVS.Management'
+
+            # A URL to an icon representing this module.
+            # IconUri = ''
+
+            # ReleaseNotes of this module
+            # ReleaseNotes = ''
+
+            # Remove this for GA version
+            Prerelease = 'dev'
+
+            # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+            # RequireLicenseAcceptance = $false
+
+            # External dependent modules of this module
+            # ExternalModuleDependencies = @()
+        }
+
+    }
+
+    # HelpInfo URI of this module
+    # HelpInfoURI = ''
+
+    # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+    # DefaultCommandPrefix = ''
+
+}

--- a/Microsoft.AVS.Migrate/Microsoft.AVS.Migrate.psm1
+++ b/Microsoft.AVS.Migrate/Microsoft.AVS.Migrate.psm1
@@ -1,0 +1,87 @@
+<#
+    .SYNOPSIS
+    Deploys the Azure Migrate appliance VM from its OVA template into the SDDC.
+
+    .DESCRIPTION
+    Downloads the Azure Migrate appliance OVA, imports it as a VM into the specified
+    cluster, maps its network to the specified NSX segment, and powers it on.
+
+    .PARAMETER VmName
+    Name of VM
+
+    .PARAMETER ClusterName
+    Name of cluster to deploy the VM in
+
+    .PARAMETER NetworkName
+    Name of nsx segment
+
+    .PARAMETER OvaUrl
+    URL of the OVA template to deploy
+
+    .EXAMPLE
+    Deploy-MigrateApplianceVM -VmName "AzMigrateAppliance" -NetworkName "TestSegment"
+#>
+function Deploy-MigrateApplianceVM {
+    [CmdletBinding()]
+    [AVSAttribute(60, UpdatesSDDC = $true)]
+    param(
+        [Parameter(Mandatory = $true, HelpMessage = "Name of VM")]
+        [ValidateNotNull()]
+        [string]$VmName,
+
+        [Parameter(Mandatory = $false, HelpMessage = "Name of cluster to deploy the VM in")]
+        [ValidateNotNull()]
+        [string]$ClusterName = "Cluster-1",
+
+        [Parameter(Mandatory = $true, HelpMessage = "Name of nsx segment")]
+        [ValidateNotNull()]
+        [string]$NetworkName,
+
+        [Parameter(Mandatory = $false, HelpMessage = "URL of the OVA template to deploy")]
+        [ValidateNotNull()]
+        [string]$OvaUrl = "https://go.microsoft.com/fwlink/?linkid=2191954"
+    )
+
+    if (Get-VM -Name $VmName -ErrorAction SilentlyContinue) {
+        throw "A VM named '$VmName' already exists. Choose a different -VmName or remove the existing VM first."
+    }
+
+    $selectedCluster = Get-Cluster -Name $ClusterName -ErrorAction Stop
+    # Any host in the cluster is acceptable - pick the first one available.
+    $vmHost = Get-VMHost -Location $selectedCluster -ErrorAction Stop | Select-Object -First 1
+    if (-not $vmHost) {
+        throw "No hosts found in cluster '$ClusterName'"
+    }
+
+    # Get-OvfConfiguration/Import-VApp do not support HTTP(S) URLs directly - they bind
+    # the string as a filesystem path - so the OVA must be downloaded locally first.
+    $ovaFileName = Join-Path ([System.IO.Path]::GetTempPath()) (Split-Path -Leaf $OvaUrl)
+    try {
+        Write-Output "Downloading OVA from '$OvaUrl' to '$ovaFileName'..."
+        Invoke-WebRequest -Uri $OvaUrl -OutFile $ovaFileName -ErrorAction Stop
+
+        $ovfConfig = Get-OvfConfiguration -Ovf $ovaFileName -ErrorAction Stop
+        if ($ovfConfig.NetworkMapping) {
+            # NetworkMapping exposes each OVF network as a dynamic CodeProperty (not a plain
+            # .NET Property) - filtering on -MemberType Properties matches unrelated base
+            # object members instead, so the mapping never actually gets applied and
+            # Import-VApp falls back to the host's (nonexistent, DVS-only) local vSwitch,
+            # failing with "Host did not have any virtual network defined."
+            $networkMapping = $ovfConfig.NetworkMapping | Get-Member -MemberType CodeProperty | Select-Object -First 1 -ExpandProperty Name
+            if ($networkMapping) {
+                $ovfConfig.NetworkMapping.$networkMapping.Value = $NetworkName
+                Write-Output "Mapping OVF network '$networkMapping' to '$NetworkName'"
+            }
+        }
+
+        Import-VApp -Source $ovaFileName -OvfConfiguration $ovfConfig -VMHost $vmHost -Name $VmName -Location $selectedCluster -Force -ErrorAction Stop
+    } finally {
+        if (Test-Path $ovaFileName) {
+            Remove-Item -Path $ovaFileName -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $vm = Get-VM -Name $VmName -ErrorAction Stop
+    Start-VM -VM $vm -Confirm:$false -ErrorAction Stop
+    Write-Output "VM $VmName created and powered on successfully"
+}


### PR DESCRIPTION
Introduces a new public Run Command cmdlet, Deploy-MigrateApplianceVM, to deploy the Azure Migrate appliance VM from its OVA template into an AVS SDDC.

This PR closes #

The changes in this PR are as follows:

1. Creates a Module for Microsoft.AVS.Migrate
2. Create the Run command cmdlets for the deployment of the migrate appliance

I have read the [contributor guidelines](CONTRIBUTING.md) and have completed the following:

* [ ] **Formatted the code** using VSCode default formatter for PowerShell.
* [ ] **Tested the code** end-to-end against an SDDC.
* [ ] **Documented the functions** using standard PowerShell markup and applied `AVSAttribute` to newly exported functions.

